### PR TITLE
Manage typescript compiler

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,7 @@ jobs:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Install Packages
-      run: npm i
+      run: npm ci
     - name: Publish Npm
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,8 @@ jobs:
       with:
         node-version: '12.x'
         registry-url: 'https://registry.npmjs.org'
+    - name: Install Packages
+      run: npm i
     - name: Publish Npm
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@
 node_modules/
 npm-debug.log
 yarn-error.log
-  
+package-lock.json
+yarn.lock
 
 # Xcode
 #
@@ -29,7 +30,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 project.xcworkspace
-      
+
 
 # Android/IntelliJ
 #
@@ -46,3 +47,8 @@ buck-out/
 
 .vscode
 .npmrc
+
+# ignore compiled
+**/*.js
+**/*.d.ts
+!typings/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 node_modules/
 npm-debug.log
 yarn-error.log
-package-lock.json
-yarn.lock
 
 # Xcode
 #

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,7 @@
+**/*.ts
+!**/*.d.ts
+scripts
+**/tests
+**/test
+
 docs

--- a/index.ts
+++ b/index.ts
@@ -81,7 +81,7 @@ async function startMeeting(params: RNZoomUsStartMeetingParams) {
 }
 
 export default {
-  ...RNZoomUs,
+  ...RNZoomUs as {},
   initialize,
   joinMeeting,
   joinMeetingWithPassword,

--- a/index.ts
+++ b/index.ts
@@ -81,7 +81,6 @@ async function startMeeting(params: RNZoomUsStartMeetingParams) {
 }
 
 export default {
-  ...RNZoomUs as {},
   initialize,
   joinMeeting,
   joinMeetingWithPassword,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,45 @@
 {
   "name": "react-native-zoom-us",
   "version": "5.0.0",
-  "lockfileVersion": 1
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/prop-types": {
+      "version": "15.7.3",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.9.56",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
+      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.63.35",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.63.35.tgz",
+      "integrity": "sha512-2uyPZoHtoUVsVO55HdrRCpgwwG2zVHLttTaR9f/BThoBAQngNWuZQ0eMGmfgRHBKXmi3TmtWjbWPxohkITLlkw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "csstype": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+      "integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "5.0.0",
   "description": "React-native bridge for ZoomUs SDK",
   "homepage": "https://github.com/mieszko4/react-native-zoom-us",
-  "main": "index.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "prepack": "npx tsc --noEmit false",
-    "postpublish": "npm run clean",
-    "clean": "npx module-kit-clean",
     "postversion": "git push && git push --tags"
   },
   "keywords": [
@@ -21,7 +20,6 @@
   },
   "devDependencies": {
     "@types/react-native": "^0.63.34",
-    "@zvs001/module-kit": "^0.0.1",
     "typescript": "4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "homepage": "https://github.com/mieszko4/react-native-zoom-us",
   "main": "index.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepack": "npx tsc --noEmit false",
+    "postpublish": "npm run clean",
+    "clean": "npx module-kit-clean",
     "postversion": "git push && git push --tags"
   },
   "keywords": [
@@ -15,6 +17,11 @@
   "author": "mieszko4",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": ">0.41.2"
+    "react-native": ">0.60.0"
+  },
+  "devDependencies": {
+    "@types/react-native": "^0.63.34",
+    "@zvs001/module-kit": "^0.0.1",
+    "typescript": "4.0.5"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "ts-node": {
-    "transpileOnly": true
-  },
   "compilerOptions": {
     "noEmit": true,
     "module": "CommonJS",
@@ -12,11 +9,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "strictNullChecks": true,
-    "experimentalDecorators": true,
-    "skipDefaultLibCheck": true,
     "noEmitOnError": false,
-    "declaration": true,
-    "allowJs": true,
-    "esModuleInterop": true
+    "declaration": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "CommonJS",
+    "target": "ES2019",
+    "moduleResolution": "node",
+    "lib": ["esnext", "es2018"],
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "experimentalDecorators": true,
+    "skipDefaultLibCheck": true,
+    "noEmitOnError": false,
+    "declaration": true,
+    "allowJs": true,
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
I found that typescript linter doesn't see package.

So I decided to copy compiler that I frequently use for ts libraries.

After compilation, I found that bug was inside `index.ts`. So compiler is not so necessary, but I think it may be useful for future.

There is also hooks for npm publish. It will run automatically.
 If there is any errors, `npm publish` will crash before publishing