### PR TITLE
Add support for full screen sharing under iOS

### DIFF
--- a/docs/IOS-SCREENSHARE.md
+++ b/docs/IOS-SCREENSHARE.md
@@ -1,0 +1,22 @@
+## Screenshare on iOS
+
+Configuring screensharing on iOS is somewhat complex. In order to set it up, you will need to do the
+following:
+
+1. Follow the instructions from Zoom for setting up (Screen Broadcast with
+ReplayKit)[https://marketplace.zoom.us/docs/sdk/native-sdks/iOS/mastering-zoom-sdk/in-meeting-function/screen-share#broadcast-device-screen]
+(make sure to add the `MobileRTCScreenShare.framework` from the ZoomSDK pod in step 3)
+2. Pass the Bundle ID you configured in step 3 of the Zoom instructions as `screenShareExtension`
+to `ZoomUs.initialize`
+3. Pass the App Group ID you configured in step 6 of the Zoom instructions as `appGroupId` to
+`ZoomUs.initialize`
+
+The resulting call to `ZoomUs.initialize` should look something like this:
+```
+await ZoomUs.initialize({
+  clientKey: '...',
+  cientSecret: '...',
+  appGroupId: 'group.com.your.Bundle',
+  screenShareExtension: 'com.your.Bundle.ScreenShare'
+});
+```

--- a/docs/IOS-SCREENSHARE.md
+++ b/docs/IOS-SCREENSHARE.md
@@ -6,9 +6,9 @@ following:
 1. Follow the instructions from Zoom for setting up (Screen Broadcast with
 ReplayKit)[https://marketplace.zoom.us/docs/sdk/native-sdks/iOS/mastering-zoom-sdk/in-meeting-function/screen-share#broadcast-device-screen]
 (make sure to add the `MobileRTCScreenShare.framework` from the ZoomSDK pod in step 3)
-2. Pass the Bundle ID you configured in step 3 of the Zoom instructions as `screenShareExtension`
+2. Pass the Bundle ID you configured in step 3 of the Zoom instructions as `iosScreenShareExtension`
 to `ZoomUs.initialize`
-3. Pass the App Group ID you configured in step 6 of the Zoom instructions as `appGroupId` to
+3. Pass the App Group ID you configured in step 6 of the Zoom instructions as `iosAppGroupId` to
 `ZoomUs.initialize`
 
 The resulting call to `ZoomUs.initialize` should look something like this:
@@ -16,7 +16,7 @@ The resulting call to `ZoomUs.initialize` should look something like this:
 await ZoomUs.initialize({
   clientKey: '...',
   cientSecret: '...',
-  appGroupId: 'group.com.your.Bundle',
-  screenShareExtension: 'com.your.Bundle.ScreenShare'
+  iosAppGroupId: 'group.com.your.Bundle',
+  iosScreenShareExtension: 'com.your.Bundle.ScreenShare'
 });
 ```

--- a/docs/IOS-SCREENSHARE.md
+++ b/docs/IOS-SCREENSHARE.md
@@ -6,7 +6,7 @@ following:
 1. Follow the instructions from Zoom for setting up (Screen Broadcast with
 ReplayKit)[https://marketplace.zoom.us/docs/sdk/native-sdks/iOS/mastering-zoom-sdk/in-meeting-function/screen-share#broadcast-device-screen]
 (make sure to add the `MobileRTCScreenShare.framework` from the ZoomSDK pod in step 3)
-2. Pass the Bundle ID you configured in step 3 of the Zoom instructions as `iosScreenShareExtension`
+2. Pass the Bundle ID you configured in step 3 of the Zoom instructions as `iosScreenShareExtensionId`
 to `ZoomUs.initialize`
 3. Pass the App Group ID you configured in step 6 of the Zoom instructions as `iosAppGroupId` to
 `ZoomUs.initialize`
@@ -17,6 +17,6 @@ await ZoomUs.initialize({
   clientKey: '...',
   cientSecret: '...',
   iosAppGroupId: 'group.com.your.Bundle',
-  iosScreenShareExtension: 'com.your.Bundle.ScreenShare'
+  iosScreenShareExtensionId: 'com.your.Bundle.ScreenShare'
 });
 ```

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ export interface RNZoomUsInitializeParams {
   clientSecret: string;
   domain?: string;
   iosAppGroupId?: string;
-  iosScreenShareExtension?: string;
+  iosScreenShareExtensionId?: string;
 }
 async function initialize(
   params: RNZoomUsInitializeParams,

--- a/index.ts
+++ b/index.ts
@@ -11,8 +11,8 @@ export interface RNZoomUsInitializeParams {
   clientKey: string;
   clientSecret: string;
   domain?: string;
-  appGroupId?: string;
-  screenShareExtension?: string;
+  iosAppGroupId?: string;
+  iosScreenShareExtension?: string;
 }
 async function initialize(
   params: RNZoomUsInitializeParams,

--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,9 @@ const DEFAULT_USER_TYPE = 2
 export interface RNZoomUsInitializeParams {
   clientKey: string;
   clientSecret: string;
-  domain?: string
+  domain?: string;
+  appGroupId?: string;
+  screenShareExtension?: string;
 }
 async function initialize(
   params: RNZoomUsInitializeParams,

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -55,7 +55,7 @@ RCT_EXPORT_METHOD(
     initializePromiseResolve = resolve;
     initializePromiseReject = reject;
 
-    screenShareExtension = data[@"screenShareExtension"];
+    screenShareExtension = data[@"iosScreenShareExtension"];
 
     MobileRTCSDKInitContext *context = [[MobileRTCSDKInitContext alloc] init];
     context.domain = data[@"domain"];
@@ -63,7 +63,7 @@ RCT_EXPORT_METHOD(
     context.locale = MobileRTC_ZoomLocale_Default;
 
     //Note: This step is optional, Method is uesd for iOS Replaykit Screen share integration,if not,just ignore this step.
-    context.appGroupId = data[@"appGroupId"];
+    context.appGroupId = data[@"iosAppGroupId"];
     BOOL initializeSuc = [[MobileRTC sharedRTC] initialize:context];
     [[[MobileRTC sharedRTC] getMeetingSettings]
       disableShowVideoPreviewWhenJoinMeeting:settings[@"disableShowVideoPreviewWhenJoinMeeting"]];

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -8,6 +8,8 @@
   RCTPromiseRejectBlock initializePromiseReject;
   RCTPromiseResolveBlock meetingPromiseResolve;
   RCTPromiseRejectBlock meetingPromiseReject;
+  // If screenShareExtension is set, the Share Content > Screen option will automatically be
+  // enabled in the UI
   NSString *screenShareExtension;
 }
 

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -55,7 +55,7 @@ RCT_EXPORT_METHOD(
     initializePromiseResolve = resolve;
     initializePromiseReject = reject;
 
-    screenShareExtension = data[@"iosScreenShareExtension"];
+    screenShareExtension = data[@"iosScreenShareExtensionId"];
 
     MobileRTCSDKInitContext *context = [[MobileRTCSDKInitContext alloc] init];
     context.domain = data[@"domain"];

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -1,4 +1,4 @@
-
+#import <ReplayKit/ReplayKit.h>
 #import "RNZoomUs.h"
 
 @implementation RNZoomUs
@@ -8,6 +8,7 @@
   RCTPromiseRejectBlock initializePromiseReject;
   RCTPromiseResolveBlock meetingPromiseResolve;
   RCTPromiseRejectBlock meetingPromiseReject;
+  NSString *screenShareExtension;
 }
 
 - (instancetype)init {
@@ -17,6 +18,7 @@
     initializePromiseReject = nil;
     meetingPromiseResolve = nil;
     meetingPromiseReject = nil;
+    screenShareExtension = nil;
   }
   return self;
 }
@@ -51,15 +53,15 @@ RCT_EXPORT_METHOD(
     initializePromiseResolve = resolve;
     initializePromiseReject = reject;
 
-
+    screenShareExtension = data[@"screenShareExtension"];
 
     MobileRTCSDKInitContext *context = [[MobileRTCSDKInitContext alloc] init];
-    context.domain = data[@"domain"];;
+    context.domain = data[@"domain"];
     context.enableLog = YES;
     context.locale = MobileRTC_ZoomLocale_Default;
 
     //Note: This step is optional, Method is uesd for iOS Replaykit Screen share integration,if not,just ignore this step.
-    // context.appGroupId = @"group.zoom.us.MobileRTCSampleExtensionReplayKit";
+    context.appGroupId = data[@"appGroupId"];
     BOOL initializeSuc = [[MobileRTC sharedRTC] initialize:context];
     [[[MobileRTC sharedRTC] getMeetingSettings]
       disableShowVideoPreviewWhenJoinMeeting:settings[@"disableShowVideoPreviewWhenJoinMeeting"]];
@@ -237,6 +239,26 @@ RCT_EXPORT_METHOD(
 
   meetingPromiseResolve = nil;
   meetingPromiseReject = nil;
+}
+
+- (void)onClickShareScreen:(UIViewController *)parentVC {
+  if (@available(iOS 12.0, *)) {
+    CGRect frame = parentVC.view.bounds;
+    RPSystemBroadcastPickerView *pickerView = [[RPSystemBroadcastPickerView alloc] initWithFrame:frame];
+    pickerView.preferredExtension = screenShareExtension;
+    SEL buttonPressed = NSSelectorFromString(@"buttonPressed:");
+    if ([pickerView respondsToSelector:buttonPressed]) {
+      [pickerView performSelector:buttonPressed withObject:nil];
+    }
+  }
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if (aSelector == @selector(onClickShareScreen:)) {
+        return screenShareExtension != nil;
+    }
+    return [super respondsToSelector:aSelector];
 }
 
 @end


### PR DESCRIPTION
This PR adds support for sharing the user's full screen under iOS using ReplayKit (with an appropriate app extension). There are still changes that need to be made in the xcode project for the app in order to enable it (documented in `docs/IOS-SCREENSHARE.md`), but these changes allow the library to be used to enable screen sharing without any further modification of the library code.