### PR TITLE
Add build.gradle file so we can use fileTree

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,11 +33,7 @@ android {
 
 
 dependencies {
-    // fileTree works for dev, but produces conflict crash (duplicated assets) on release build
-    // implementation fileTree(dir: "libs", include: ["*.aar"])
-
-    implementation 'us.zoom.sdk:commonlib@aar'
-    implementation 'us.zoom.sdk:mobilertc@aar'
+    implementation fileTree(dir: 'libs', include: ['*'])
     implementation 'com.facebook.react:react-native:+' // From node_modules
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.appcompat:appcompat:1.0.0'

--- a/android/libs/build.gradle
+++ b/android/libs/build.gradle
@@ -1,0 +1,3 @@
+configurations.maybeCreate("default")
+artifacts.add("default", file('commonlib.aar'))
+artifacts.add("default", file('mobilertc.aar'))


### PR DESCRIPTION
As far as I can tell, by adding `libs/build.gradle`, we can use `fileTree()` for the release build as well.