### PR TITLE
Fire RN events on meeting- and auth events

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -396,43 +396,43 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   private String getAuthErrorName(final int errorCode) {
     switch (errorCode) {
-      case ZoomError.ZOOM_ERROR_SUCCESS: return "success";
-      case ZoomError.ZOOM_ERROR_INVALID_ARGUMENTS: return "invalidArguments"; // Android only
-      case ZoomError.ZOOM_ERROR_ILLEGAL_APP_KEY_OR_SECRET: return "illegalAppKeyOrSecret"; // Android only
-      case ZoomError.ZOOM_ERROR_NETWORK_UNAVAILABLE: return "networkUnavailable"; // Android only
       case ZoomError.ZOOM_ERROR_AUTHRET_CLIENT_INCOMPATIBLEE: return "clientIncompatible";
+      case ZoomError.ZOOM_ERROR_SUCCESS: return "success";
       case ZoomError.ZOOM_ERROR_DEVICE_NOT_SUPPORTED: return "deviceNotSupported"; // Android only
+      case ZoomError.ZOOM_ERROR_ILLEGAL_APP_KEY_OR_SECRET: return "illegalAppKeyOrSecret"; // Android only
+      case ZoomError.ZOOM_ERROR_INVALID_ARGUMENTS: return "invalidArguments"; // Android only
+      case ZoomError.ZOOM_ERROR_NETWORK_UNAVAILABLE: return "networkUnavailable"; // Android only
       default: return "unknown";
     }
   }
 
   private String getMeetErrorName(final int errorCode) {
     switch (errorCode) {
-      case MeetingError.MEETING_ERROR_SUCCESS: return "success";
-      case MeetingError.MEETING_ERROR_INCORRECT_MEETING_NUMBER: return "incorrectMeetingNumber"; // Android only
-      case MeetingError.MEETING_ERROR_TIMEOUT: return "timeout"; // Android only
-      case MeetingError.MEETING_ERROR_NETWORK_UNAVAILABLE: return "networkUnavailable"; // Android only
+      case MeetingError.MEETING_ERROR_INVALID_ARGUMENTS: return "invalidArguments";
       case MeetingError.MEETING_ERROR_CLIENT_INCOMPATIBLE: return "meetingClientIncompatible";
-      case MeetingError.MEETING_ERROR_NETWORK_ERROR: return "networkError";
-      case MeetingError.MEETING_ERROR_MMR_ERROR: return "mmrError";
-      case MeetingError.MEETING_ERROR_SESSION_ERROR: return "sessionError";
-      case MeetingError.MEETING_ERROR_MEETING_OVER: return "meetingOver";
-      case MeetingError.MEETING_ERROR_MEETING_NOT_EXIST: return "meetingNotExist";
-      case MeetingError.MEETING_ERROR_USER_FULL: return "meetingUserFull";
-      case MeetingError.MEETING_ERROR_NO_MMR: return "noMMR";
       case MeetingError.MEETING_ERROR_LOCKED: return "meetingLocked";
+      case MeetingError.MEETING_ERROR_MEETING_NOT_EXIST: return "meetingNotExist";
+      case MeetingError.MEETING_ERROR_MEETING_OVER: return "meetingOver";
       case MeetingError.MEETING_ERROR_RESTRICTED: return "meetingRestricted";
       case MeetingError.MEETING_ERROR_RESTRICTED_JBH: return "meetingRestrictedJBH";
-      case MeetingError.MEETING_ERROR_WEB_SERVICE_FAILED: return "webServiceFailed"; // Android only
+      case MeetingError.MEETING_ERROR_USER_FULL: return "meetingUserFull";
+      case MeetingError.MEETING_ERROR_MMR_ERROR: return "mmrError";
+      case MeetingError.MEETING_ERROR_NETWORK_ERROR: return "networkError";
+      case MeetingError.MEETING_ERROR_NO_MMR: return "noMMR";
+      case MeetingError.MEETING_ERROR_HOST_DENY_EMAIL_REGISTER_WEBINAR: return "registerWebinarDeniedEmail";
+      case MeetingError.MEETING_ERROR_WEBINAR_ENFORCE_LOGIN: return "registerWebinarEnforceLogin";
       case MeetingError.MEETING_ERROR_REGISTER_WEBINAR_FULL: return "registerWebinarFull";
       case MeetingError.MEETING_ERROR_DISALLOW_HOST_RESGISTER_WEBINAR: return "registerWebinarHostRegister";
       case MeetingError.MEETING_ERROR_DISALLOW_PANELIST_REGISTER_WEBINAR: return "registerWebinarPanelistRegister";
-      case MeetingError.MEETING_ERROR_HOST_DENY_EMAIL_REGISTER_WEBINAR: return "registerWebinarDeniedEmail";
-      case MeetingError.MEETING_ERROR_WEBINAR_ENFORCE_LOGIN: return "registerWebinarEnforceLogin";
-      case MeetingError.MEETING_ERROR_EXIT_WHEN_WAITING_HOST_START: return "exitWhenWaitingHostStart"; // Android only
       case MeetingError.MEETING_ERROR_REMOVED_BY_HOST: return "removedByHost";
-      case MeetingError.MEETING_ERROR_INVALID_ARGUMENTS: return "invalidArguments";
+      case MeetingError.MEETING_ERROR_SESSION_ERROR: return "sessionError";
+      case MeetingError.MEETING_ERROR_SUCCESS: return "success";
+      case MeetingError.MEETING_ERROR_EXIT_WHEN_WAITING_HOST_START: return "exitWhenWaitingHostStart"; // Android only
+      case MeetingError.MEETING_ERROR_INCORRECT_MEETING_NUMBER: return "incorrectMeetingNumber"; // Android only
       case MeetingError.MEETING_ERROR_INVALID_STATUS: return "invalidStatus"; // Android only
+      case MeetingError.MEETING_ERROR_NETWORK_UNAVAILABLE: return "networkUnavailable"; // Android only
+      case MeetingError.MEETING_ERROR_TIMEOUT: return "timeout"; // Android only
+      case MeetingError.MEETING_ERROR_WEB_SERVICE_FAILED: return "webServiceFailed"; // Android only
       default: return "unknown";
     }
   }
@@ -441,8 +441,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     switch (reason) {
       case MeetingEndReason.END_BY_HOST: return "endedByHost";
       case MeetingEndReason.END_BY_HOST_START_ANOTHERMEETING: return "endedByHostForAnotherMeeting";
-      case MeetingEndReason.END_BY_SDK_CONNECTION_BROKEN: return "endedConnectBroken";
       case MeetingEndReason.END_BY_SELF: return "endedBySelf";
+      case MeetingEndReason.END_BY_SDK_CONNECTION_BROKEN: return "endedConnectBroken";
       case MeetingEndReason.END_FOR_FREEMEET_TIMEOUT: return "endedFreeMeetingTimeout";
       case MeetingEndReason.END_FOR_JBHTIMEOUT: return "endedJBHTimeout";
       case MeetingEndReason.END_FOR_NOATEENDEE: return "endedNoAttendee";

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -21,6 +21,7 @@ import us.zoom.sdk.InMeetingService;
 import us.zoom.sdk.InMeetingServiceListener;
 import us.zoom.sdk.InMeetingShareController;
 import us.zoom.sdk.MeetingEndReason;
+import us.zoom.sdk.MeetingSettingsHelper;
 import us.zoom.sdk.ZoomSDK;
 import us.zoom.sdk.ZoomError;
 import us.zoom.sdk.ZoomSDKInitializeListener;
@@ -228,7 +229,10 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       registerListener();
       initializePromise.resolve("Initialize Zoom SDK successfully.");
 
-      ZoomSDK.getInstance().getMeetingSettingsHelper().disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
+      final MeetingSettingsHelper meetingSettingsHelper = ZoomSDK.getInstance().getMeetingSettingsHelper();
+      if (meetingSettingsHelper != null) {
+        meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
+      }
     }
   }
 
@@ -279,12 +283,18 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     Log.i(TAG, "unregisterListener");
     ZoomSDK zoomSDK = ZoomSDK.getInstance();
     if(zoomSDK.isInitialized()) {
-      MeetingService meetingService = zoomSDK.getMeetingService();
-      meetingService.removeListener(this);
-      InMeetingService inMeetingService = zoomSDK.getInMeetingService();
-      inMeetingService.removeListener(this);
-      InMeetingShareController inMeetingShareController = inMeetingService.getInMeetingShareController();
-      inMeetingShareController.removeListener(this);
+      final MeetingService meetingService = zoomSDK.getMeetingService();
+      if (meetingService != null) {
+        meetingService.removeListener(this);
+      }
+      final InMeetingService inMeetingService = zoomSDK.getInMeetingService();
+      if (inMeetingService != null) {
+        inMeetingService.removeListener(this);
+        final InMeetingShareController inMeetingShareController = inMeetingService.getInMeetingShareController();
+        if (inMeetingShareController != null) {
+          inMeetingShareController.removeListener(this);
+        }
+      }
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { NativeEventEmitter, NativeModules } from 'react-native'
+import { EventSubscriptionVendor, NativeModules } from 'react-native'
 import invariant from 'invariant'
 
 const { RNZoomUs } = NativeModules
@@ -84,7 +84,7 @@ async function startMeeting(params: RNZoomUsStartMeetingParams) {
   return RNZoomUs.startMeeting({ userType, ...params, meetingNumber })
 }
 
-export const ZoomEmitter = RNZoomUs as NativeEventEmitter;
+export const ZoomEmitter = RNZoomUs as EventSubscriptionVendor;
 
 export default {
   initialize,

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native'
+import { NativeEventEmitter, NativeModules } from 'react-native'
 import invariant from 'invariant'
 
 const { RNZoomUs } = NativeModules
@@ -83,6 +83,8 @@ async function startMeeting(params: RNZoomUsStartMeetingParams) {
 
   return RNZoomUs.startMeeting({ userType, ...params, meetingNumber })
 }
+
+export const ZoomEmitter = RNZoomUs as NativeEventEmitter;
 
 export default {
   initialize,

--- a/ios/RNZoomUs.h
+++ b/ios/RNZoomUs.h
@@ -5,9 +5,10 @@
 #import <React/RCTBridgeModule.h>
 #endif
 
+#import "RCTEventEmitter.h"
 #import <MobileRTC/MobileRTC.h>
 
-@interface RNZoomUs : NSObject <RCTBridgeModule, MobileRTCAuthDelegate, MobileRTCMeetingServiceDelegate>
+@interface RNZoomUs : RCTEventEmitter<RCTBridgeModule, MobileRTCAuthDelegate, MobileRTCMeetingServiceDelegate>
 
 @end
 

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -247,6 +247,10 @@ RCT_EXPORT_METHOD(
   meetingPromiseReject = nil;
 }
 
+- (void)onMeetingEndedReason:(MobileRTCMeetingEndReason)reason {
+  [self sendEventWithName:@"MeetingEvent" event:[self meetingEndReasonName:reason]];
+}
+
 #pragma mark - Screen share functionality
 
 - (void)onSinkMeetingActiveShare:(NSUInteger)userID {
@@ -357,6 +361,19 @@ RCT_EXPORT_METHOD(
     case MobileRTCMeetError_VBRemoveNone: return @"vbRemoveNone"; // iOS only
     case MobileRTCMeetError_VBNoSupport: return @"vbNoSupport"; // iOS only
     default: return @"unknown";
+  }
+}
+
+- (NSString *)meetingEndReasonName:(MobileRTCMeetingEndReason)reason {
+  switch (reason) {
+    case MobileRTCMeetingEndReason_SelfLeave: return @"endedBySelf";
+    case MobileRTCMeetingEndReason_RemovedByHost: return @"endedRemovedByHost";
+    case MobileRTCMeetingEndReason_EndByHost: return @"endedByHost";
+    case MobileRTCMeetingEndReason_JBHTimeout: return @"endedJBHTimeout";
+    case MobileRTCMeetingEndReason_FreeMeetingTimeout: return @"endedFreeMeetingTimeout";
+    case MobileRTCMeetingEndReason_HostEndForAnotherMeeting: return @"endedByHostForAnotherMeeting";
+    case MobileRTCMeetingEndReason_ConnectBroken: return @"endedConnectBroken";
+    default: return @"endedUnknownReason";
   }
 }
 

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -306,73 +306,73 @@ RCT_EXPORT_METHOD(
 
 - (NSString *)authErrorName:(MobileRTCAuthError)error {
   switch (error) {
+    case MobileRTCAuthError_ClientIncompatible: return @"clientIncompatible";
     case MobileRTCAuthError_Success: return @"success";
+    case MobileRTCAuthError_AccountNotEnableSDK: return @"accountNotEnableSDK"; // iOS only
+    case MobileRTCAuthError_AccountNotSupport: return @"accountNotSupport"; // iOS only
     case MobileRTCAuthError_KeyOrSecretEmpty: return @"keyOrSecretEmpty"; // iOS only
     case MobileRTCAuthError_KeyOrSecretWrong: return @"keyOrSecretWrong"; // iOS only
-    case MobileRTCAuthError_AccountNotSupport: return @"accountNotSupport"; // iOS only
-    case MobileRTCAuthError_AccountNotEnableSDK: return @"accountNotEnableSDK"; // iOS only
-    case MobileRTCAuthError_ServiceBusy: return @"serviceBusy"; // iOS only
+    case MobileRTCAuthError_NetworkIssue: return @"networkIssue"; // iOS only
     case MobileRTCAuthError_None: return @"none"; // iOS only
     case MobileRTCAuthError_OverTime: return @"overTime"; // iOS only
-    case MobileRTCAuthError_NetworkIssue: return @"networkIssue"; // iOS only
-    case MobileRTCAuthError_ClientIncompatible: return @"clientIncompatible";
+    case MobileRTCAuthError_ServiceBusy: return @"serviceBusy"; // iOS only
     default: return @"unknown";
   }
 }
 
 - (NSString *)meetErrorName:(MobileRTCMeetError)error {
   switch (error) {
-    case MobileRTCMeetError_Success: return @"success";
-    case MobileRTCMeetError_NetworkError: return @"networkError";
-    case MobileRTCMeetError_ReconnectError: return @"reconnectError"; // iOS only
-    case MobileRTCMeetError_MMRError: return @"mmrError";
-    case MobileRTCMeetError_PasswordError: return @"passwordError"; // iOS only
-    case MobileRTCMeetError_SessionError: return @"sessionError";
-    case MobileRTCMeetError_MeetingOver: return @"meetingOver";
-    case MobileRTCMeetError_MeetingNotStart: return @"meetingNotStart"; // iOS only
-    case MobileRTCMeetError_MeetingNotExist: return @"meetingNotExist";
-    case MobileRTCMeetError_MeetingUserFull: return @"meetingUserFull";
+    case MobileRTCMeetError_InvalidArguments: return @"invalidArguments";
     case MobileRTCMeetError_MeetingClientIncompatible: return @"meetingClientIncompatible";
-    case MobileRTCMeetError_NoMMR: return @"noMMR";
     case MobileRTCMeetError_MeetingLocked: return @"meetingLocked";
+    case MobileRTCMeetError_MeetingNotExist: return @"meetingNotExist";
+    case MobileRTCMeetError_MeetingOver: return @"meetingOver";
     case MobileRTCMeetError_MeetingRestricted: return @"meetingRestricted";
     case MobileRTCMeetError_MeetingRestrictedJBH: return @"meetingRestrictedJBH";
-    case MobileRTCMeetError_CannotEmitWebRequest: return @"cannotEmitWebRequest"; // iOS only
-    case MobileRTCMeetError_CannotStartTokenExpire: return @"cannotStartTokenExpire"; // iOS only
-    case MobileRTCMeetError_VideoError: return @"videoError"; // iOS only
-    case MobileRTCMeetError_AudioAutoStartError: return @"audioAutoStartError"; // iOS only
+    case MobileRTCMeetError_MeetingUserFull: return @"meetingUserFull";
+    case MobileRTCMeetError_MMRError: return @"mmrError";
+    case MobileRTCMeetError_NetworkError: return @"networkError";
+    case MobileRTCMeetError_NoMMR: return @"noMMR";
+    case MobileRTCMeetError_RegisterWebinarDeniedEmail: return @"registerWebinarDeniedEmail";
+    case MobileRTCMeetError_RegisterWebinarEnforceLogin: return @"registerWebinarEnforceLogin";
     case MobileRTCMeetError_RegisterWebinarFull: return @"registerWebinarFull";
     case MobileRTCMeetError_RegisterWebinarHostRegister: return @"registerWebinarHostRegister";
     case MobileRTCMeetError_RegisterWebinarPanelistRegister: return @"registerWebinarPanelistRegister";
-    case MobileRTCMeetError_RegisterWebinarDeniedEmail: return @"registerWebinarDeniedEmail";
-    case MobileRTCMeetError_RegisterWebinarEnforceLogin: return @"registerWebinarEnforceLogin";
-    case MobileRTCMeetError_ZCCertificateChanged: return @"zcCertificateChanged"; // iOS only
-    case MobileRTCMeetError_VanityNotExist: return @"vanityNotExist"; // iOS only
-    case MobileRTCMeetError_JoinWebinarWithSameEmail: return @"joinWebinarWithSameEmail"; // iOS only
-    case MobileRTCMeetError_WriteConfigFile: return @"writeConfigFile"; // iOS only
     case MobileRTCMeetError_RemovedByHost: return @"removedByHost";
-    case MobileRTCMeetError_InvalidArguments: return @"invalidArguments";
-    case MobileRTCMeetError_InvalidUserType: return @"invalidUserType"; // iOS only
+    case MobileRTCMeetError_SessionError: return @"sessionError";
+    case MobileRTCMeetError_Success: return @"success";
+    case MobileRTCMeetError_AudioAutoStartError: return @"audioAutoStartError"; // iOS only
+    case MobileRTCMeetError_CannotEmitWebRequest: return @"cannotEmitWebRequest"; // iOS only
+    case MobileRTCMeetError_CannotStartTokenExpire: return @"cannotStartTokenExpire"; // iOS only
     case MobileRTCMeetError_InAnotherMeeting: return @"inAnotherMeeting"; // iOS only
+    case MobileRTCMeetError_InvalidUserType: return @"invalidUserType"; // iOS only
+    case MobileRTCMeetError_JoinWebinarWithSameEmail: return @"joinWebinarWithSameEmail"; // iOS only
+    case MobileRTCMeetError_MeetingNotStart: return @"meetingNotStart"; // iOS only
+    case MobileRTCMeetError_PasswordError: return @"passwordError"; // iOS only
+    case MobileRTCMeetError_ReconnectError: return @"reconnectError"; // iOS only
+    case MobileRTCMeetError_VanityNotExist: return @"vanityNotExist"; // iOS only
+    case MobileRTCMeetError_VBMaximumNum: return @"vbMaximumNum"; // iOS only
+    case MobileRTCMeetError_VBNoSupport: return @"vbNoSupport"; // iOS only
+    case MobileRTCMeetError_VBRemoveNone: return @"vbRemoveNone"; // iOS only
+    case MobileRTCMeetError_VBSaveImage: return @"vbSaveImage"; // iOS only
     // _VBSetError has the same value as _VBBase so we are excluding _VBBase
     case MobileRTCMeetError_VBSetError: return @"vbSetError"; // iOS only
-    case MobileRTCMeetError_VBMaximumNum: return @"vbMaximumNum"; // iOS only
-    case MobileRTCMeetError_VBSaveImage: return @"vbSaveImage"; // iOS only
-    case MobileRTCMeetError_VBRemoveNone: return @"vbRemoveNone"; // iOS only
-    case MobileRTCMeetError_VBNoSupport: return @"vbNoSupport"; // iOS only
+    case MobileRTCMeetError_VideoError: return @"videoError"; // iOS only
+    case MobileRTCMeetError_WriteConfigFile: return @"writeConfigFile"; // iOS only
+    case MobileRTCMeetError_ZCCertificateChanged: return @"zcCertificateChanged"; // iOS only
     default: return @"unknown";
   }
 }
 
 - (NSString *)meetingEndReasonName:(MobileRTCMeetingEndReason)reason {
   switch (reason) {
-    case MobileRTCMeetingEndReason_SelfLeave: return @"endedBySelf";
-    case MobileRTCMeetingEndReason_RemovedByHost: return @"endedRemovedByHost";
     case MobileRTCMeetingEndReason_EndByHost: return @"endedByHost";
-    case MobileRTCMeetingEndReason_JBHTimeout: return @"endedJBHTimeout";
-    case MobileRTCMeetingEndReason_FreeMeetingTimeout: return @"endedFreeMeetingTimeout";
     case MobileRTCMeetingEndReason_HostEndForAnotherMeeting: return @"endedByHostForAnotherMeeting";
+    case MobileRTCMeetingEndReason_SelfLeave: return @"endedBySelf";
     case MobileRTCMeetingEndReason_ConnectBroken: return @"endedConnectBroken";
+    case MobileRTCMeetingEndReason_FreeMeetingTimeout: return @"endedFreeMeetingTimeout";
+    case MobileRTCMeetingEndReason_JBHTimeout: return @"endedJBHTimeout";
+    case MobileRTCMeetingEndReason_RemovedByHost: return @"endedRemovedByHost";
     default: return @"endedUnknownReason";
   }
 }

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -278,20 +278,20 @@ RCT_EXPORT_METHOD(
 
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
-    if (aSelector == @selector(onClickShareScreen:)) {
-        return screenShareExtension != nil;
-    }
-    return [super respondsToSelector:aSelector];
+  if (aSelector == @selector(onClickShareScreen:)) {
+    return screenShareExtension != nil;
+  }
+  return [super respondsToSelector:aSelector];
 }
 
 #pragma mark - React Native event emitters and event handling
 
 - (void)startObserving {
-    hasObservers = YES;
+  hasObservers = YES;
 }
 
 - (void)stopObserving {
-    hasObservers = NO;
+  hasObservers = NO;
 }
 
 - (NSArray<NSString *> *)supportedEvents {
@@ -299,9 +299,9 @@ RCT_EXPORT_METHOD(
 }
 
 - (void)sendEventWithName:(NSString *)name event:(NSString *)event {
-    if (hasObservers) {
-        [self sendEventWithName:name body:@{@"event": event}];
-    }
+  if (hasObservers) {
+    [self sendEventWithName:name body:@{@"event": event}];
+  }
 }
 
 - (NSString *)authErrorName:(MobileRTCAuthError)error {

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -250,11 +250,14 @@ RCT_EXPORT_METHOD(
 #pragma mark - Screen share functionality
 
 - (void)onSinkMeetingActiveShare:(NSUInteger)userID {
+  MobileRTCMeetingService *ms = [[MobileRTC sharedRTC] getMeetingService];
+  if (ms) {
     if (userID == 0) {
-        [self sendEventWithName:@"MeetingEvent" event:@"screenShareStopped"];
-    } else {
-        [self sendEventWithName:@"MeetingEvent" event:@"screenShareStarted"];
+      [self sendEventWithName:@"MeetingEvent" event:@"screenShareStopped"];
+    } else if (userID == [ms myselfUserID]){
+      [self sendEventWithName:@"MeetingEvent" event:@"screenShareStarted"];
     }
+  }
 }
 
 - (void)onClickShareScreen:(UIViewController *)parentVC {

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -4,6 +4,7 @@
 @implementation RNZoomUs
 {
   BOOL isInitialized;
+  BOOL hasObservers;
   RCTPromiseResolveBlock initializePromiseResolve;
   RCTPromiseRejectBlock initializePromiseReject;
   RCTPromiseResolveBlock meetingPromiseResolve;
@@ -179,6 +180,7 @@ RCT_EXPORT_METHOD(
 
 - (void)onMobileRTCAuthReturn:(MobileRTCAuthError)returnValue {
   NSLog(@"nZoomSDKInitializeResult, errorCode=%d", returnValue);
+  [self sendEventWithName:@"AuthEvent" event:[self authErrorName:returnValue]];
   if(returnValue != MobileRTCAuthError_Success) {
     initializePromiseReject(
       @"ERR_ZOOM_INITIALIZATION",
@@ -192,6 +194,7 @@ RCT_EXPORT_METHOD(
 
 - (void)onMeetingReturn:(MobileRTCMeetError)errorCode internalError:(NSInteger)internalErrorCode {
   NSLog(@"onMeetingReturn, error=%d, internalErrorCode=%zd", errorCode, internalErrorCode);
+  [self sendEventWithName:@"MeetingEvent" event:[self meetErrorName:errorCode]];
 
   if (!meetingPromiseResolve) {
     return;
@@ -228,6 +231,7 @@ RCT_EXPORT_METHOD(
 
 - (void)onMeetingError:(MobileRTCMeetError)errorCode message:(NSString *)message {
   NSLog(@"onMeetingError, errorCode=%d, message=%@", errorCode, message);
+  [self sendEventWithName:@"MeetingEvent" event:[self meetErrorName:errorCode]];
 
   if (!meetingPromiseResolve) {
     return;
@@ -241,6 +245,16 @@ RCT_EXPORT_METHOD(
 
   meetingPromiseResolve = nil;
   meetingPromiseReject = nil;
+}
+
+#pragma mark - Screen share functionality
+
+- (void)onSinkMeetingActiveShare:(NSUInteger)userID {
+    if (userID == 0) {
+        [self sendEventWithName:@"MeetingEvent" event:@"screenShareStopped"];
+    } else {
+        [self sendEventWithName:@"MeetingEvent" event:@"screenShareStarted"];
+    }
 }
 
 - (void)onClickShareScreen:(UIViewController *)parentVC {
@@ -261,6 +275,86 @@ RCT_EXPORT_METHOD(
         return screenShareExtension != nil;
     }
     return [super respondsToSelector:aSelector];
+}
+
+#pragma mark - React Native event emitters and event handling
+
+- (void)startObserving {
+    hasObservers = YES;
+}
+
+- (void)stopObserving {
+    hasObservers = NO;
+}
+
+- (NSArray<NSString *> *)supportedEvents {
+  return @[@"AuthEvent", @"MeetingEvent"];
+}
+
+- (void)sendEventWithName:(NSString *)name event:(NSString *)event {
+    if (hasObservers) {
+        [self sendEventWithName:name body:@{@"event": event}];
+    }
+}
+
+- (NSString *)authErrorName:(MobileRTCAuthError)error {
+  switch (error) {
+    case MobileRTCAuthError_Success: return @"success";
+    case MobileRTCAuthError_KeyOrSecretEmpty: return @"keyOrSecretEmpty"; // iOS only
+    case MobileRTCAuthError_KeyOrSecretWrong: return @"keyOrSecretWrong"; // iOS only
+    case MobileRTCAuthError_AccountNotSupport: return @"accountNotSupport"; // iOS only
+    case MobileRTCAuthError_AccountNotEnableSDK: return @"accountNotEnableSDK"; // iOS only
+    case MobileRTCAuthError_ServiceBusy: return @"serviceBusy"; // iOS only
+    case MobileRTCAuthError_None: return @"none"; // iOS only
+    case MobileRTCAuthError_OverTime: return @"overTime"; // iOS only
+    case MobileRTCAuthError_NetworkIssue: return @"networkIssue"; // iOS only
+    case MobileRTCAuthError_ClientIncompatible: return @"clientIncompatible";
+    default: return @"unknown";
+  }
+}
+
+- (NSString *)meetErrorName:(MobileRTCMeetError)error {
+  switch (error) {
+    case MobileRTCMeetError_Success: return @"success";
+    case MobileRTCMeetError_NetworkError: return @"networkError";
+    case MobileRTCMeetError_ReconnectError: return @"reconnectError"; // iOS only
+    case MobileRTCMeetError_MMRError: return @"mmrError";
+    case MobileRTCMeetError_PasswordError: return @"passwordError"; // iOS only
+    case MobileRTCMeetError_SessionError: return @"sessionError";
+    case MobileRTCMeetError_MeetingOver: return @"meetingOver";
+    case MobileRTCMeetError_MeetingNotStart: return @"meetingNotStart"; // iOS only
+    case MobileRTCMeetError_MeetingNotExist: return @"meetingNotExist";
+    case MobileRTCMeetError_MeetingUserFull: return @"meetingUserFull";
+    case MobileRTCMeetError_MeetingClientIncompatible: return @"meetingClientIncompatible";
+    case MobileRTCMeetError_NoMMR: return @"noMMR";
+    case MobileRTCMeetError_MeetingLocked: return @"meetingLocked";
+    case MobileRTCMeetError_MeetingRestricted: return @"meetingRestricted";
+    case MobileRTCMeetError_MeetingRestrictedJBH: return @"meetingRestrictedJBH";
+    case MobileRTCMeetError_CannotEmitWebRequest: return @"cannotEmitWebRequest"; // iOS only
+    case MobileRTCMeetError_CannotStartTokenExpire: return @"cannotStartTokenExpire"; // iOS only
+    case MobileRTCMeetError_VideoError: return @"videoError"; // iOS only
+    case MobileRTCMeetError_AudioAutoStartError: return @"audioAutoStartError"; // iOS only
+    case MobileRTCMeetError_RegisterWebinarFull: return @"registerWebinarFull";
+    case MobileRTCMeetError_RegisterWebinarHostRegister: return @"registerWebinarHostRegister";
+    case MobileRTCMeetError_RegisterWebinarPanelistRegister: return @"registerWebinarPanelistRegister";
+    case MobileRTCMeetError_RegisterWebinarDeniedEmail: return @"registerWebinarDeniedEmail";
+    case MobileRTCMeetError_RegisterWebinarEnforceLogin: return @"registerWebinarEnforceLogin";
+    case MobileRTCMeetError_ZCCertificateChanged: return @"zcCertificateChanged"; // iOS only
+    case MobileRTCMeetError_VanityNotExist: return @"vanityNotExist"; // iOS only
+    case MobileRTCMeetError_JoinWebinarWithSameEmail: return @"joinWebinarWithSameEmail"; // iOS only
+    case MobileRTCMeetError_WriteConfigFile: return @"writeConfigFile"; // iOS only
+    case MobileRTCMeetError_RemovedByHost: return @"removedByHost";
+    case MobileRTCMeetError_InvalidArguments: return @"invalidArguments";
+    case MobileRTCMeetError_InvalidUserType: return @"invalidUserType"; // iOS only
+    case MobileRTCMeetError_InAnotherMeeting: return @"inAnotherMeeting"; // iOS only
+    // _VBSetError has the same value as _VBBase so we are excluding _VBBase
+    case MobileRTCMeetError_VBSetError: return @"vbSetError"; // iOS only
+    case MobileRTCMeetError_VBMaximumNum: return @"vbMaximumNum"; // iOS only
+    case MobileRTCMeetError_VBSaveImage: return @"vbSaveImage"; // iOS only
+    case MobileRTCMeetError_VBRemoveNone: return @"vbRemoveNone"; // iOS only
+    case MobileRTCMeetError_VBNoSupport: return @"vbNoSupport"; // iOS only
+    default: return @"unknown";
+  }
 }
 
 @end


### PR DESCRIPTION
This adds RN events on:
* Auth initialization
* Meeting status changes
* Meeting departure
* Screen sharing start/stop

We could fire events on other things as well, but these are the ones that I have needed to handle screen sharing in our React Native app smoothly. I'm not certain this is the right approach, since—particularly on Android with InMeetingServiceListener methods—it results in a rather large amount of additional code, but it works well for us.