### PR TITLE
Add support for JWT SDK initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ await ZoomUs.initialize({
   clientSecret: '...',
 })
 
+// initialize using JWT
+await ZoomUs.initialize({
+  jwtToken: '...',
+})
+
 // initialize with extra config
 await ZoomUs.initialize({
   clientKey: '...',

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -25,6 +25,7 @@ import us.zoom.sdk.MeetingSettingsHelper;
 import us.zoom.sdk.ZoomSDK;
 import us.zoom.sdk.ZoomError;
 import us.zoom.sdk.ZoomSDKInitializeListener;
+import us.zoom.sdk.ZoomSDKInitParams;
 
 import us.zoom.sdk.MeetingStatus;
 import us.zoom.sdk.MeetingError;
@@ -82,13 +83,26 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
           @Override
           public void run() {
             ZoomSDK zoomSDK = ZoomSDK.getInstance();
-            zoomSDK.initialize(
-              reactContext.getCurrentActivity(),
-              params.getString("clientKey"),
-              params.getString("clientSecret"),
-              params.getString("domain"),
-              RNZoomUsModule.this
-            );
+
+            if (params.hasKey("jwtToken")) {
+                ZoomSDKInitParams initParams = new ZoomSDKInitParams();
+                initParams.jwtToken = params.getString("jwtToken");
+                initParams.domain = params.getString("domain");
+
+                zoomSDK.initialize(
+                  reactContext.getCurrentActivity(),
+                  RNZoomUsModule.this,
+                  initParams
+                );
+            } else {
+              zoomSDK.initialize(
+                reactContext.getCurrentActivity(),
+                params.getString("clientKey"),
+                params.getString("clientSecret"),
+                params.getString("domain"),
+                RNZoomUsModule.this
+              );
+            }
           }
       });
     } catch (Exception ex) {

--- a/index.ts
+++ b/index.ts
@@ -7,15 +7,23 @@ if (!RNZoomUs) console.error('RNZoomUs native module is not linked.')
 
 const DEFAULT_USER_TYPE = 2
 
-export interface RNZoomUsInitializeParams {
-  clientKey: string;
-  clientSecret: string;
+interface RNZoomUsInitializeCommonParams {
   domain?: string;
   iosAppGroupId?: string;
   iosScreenShareExtensionId?: string;
 }
+export interface RNZoomUsInitializeParams extends RNZoomUsInitializeCommonParams {
+  clientKey: string;
+  clientSecret: string;
+}
+
+export interface RNZoomUsSDKInitParams extends RNZoomUsInitializeCommonParams {
+  jwtToken: string;
+  // we don't care for the rest, for now
+}
+
 async function initialize(
-  params: RNZoomUsInitializeParams,
+  params: RNZoomUsInitializeParams|RNZoomUsSDKInitParams,
   settings: {
     // ios only
     disableShowVideoPreviewWhenJoinMeeting?: boolean
@@ -29,8 +37,12 @@ async function initialize(
     'Check Link: https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md',
   )
 
-  invariant(params.clientKey, 'ZoomUs.initialize requires clientKey')
-  invariant(params.clientSecret, 'ZoomUs.initialize requires clientSecret')
+  if ('jwtToken' in params) {
+    invariant(params.jwtToken, 'ZoomUs.initialize requires jwtToken')
+  } else {
+    invariant(params.clientKey, 'ZoomUs.initialize requires clientKey')
+    invariant(params.clientSecret, 'ZoomUs.initialize requires clientSecret')
+  }
 
   if (!params.domain) params.domain = 'zoom.us'
 

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -13,6 +13,8 @@
   // If screenShareExtension is set, the Share Content > Screen option will automatically be
   // enabled in the UI
   NSString *screenShareExtension;
+
+  NSString *jwtToken;
 }
 
 - (instancetype)init {
@@ -24,6 +26,7 @@
     meetingPromiseResolve = nil;
     meetingPromiseReject = nil;
     screenShareExtension = nil;
+    jwtToken = nil;
   }
   return self;
 }
@@ -59,6 +62,7 @@ RCT_EXPORT_METHOD(
     initializePromiseReject = reject;
 
     screenShareExtension = data[@"iosScreenShareExtensionId"];
+    jwtToken = data[@"jwtToken"];
 
     MobileRTCSDKInitContext *context = [[MobileRTCSDKInitContext alloc] init];
     context.domain = data[@"domain"];
@@ -75,9 +79,12 @@ RCT_EXPORT_METHOD(
     if (authService)
     {
       authService.delegate = self;
-
-      authService.clientKey = data[@"clientKey"];
-      authService.clientSecret = data[@"clientSecret"];
+      if (jwtToken != nil) {
+        authService.jwtToken = data[@"jwtToken"];
+      } else {
+        authService.clientKey = data[@"clientKey"];
+        authService.clientSecret = data[@"clientSecret"];
+      }
 
       [authService sdkAuth];
     } else {


### PR DESCRIPTION
This patch adds support for SDK initialization using JWT as alternative of classic SDK Key & Secret

See: 
 - https://zoom.github.io/zoom-sdk-android/us/zoom/sdk/ZoomSDK.html#initialize-android.content.Context-us.zoom.sdk.ZoomSDKInitializeListener-us.zoom.sdk.ZoomSDKInitParams-
 - https://marketplace.zoom.us/docs/sdk/native-sdks/iOS/mastering-zoom-sdk/sdk-initialization
 - https://marketplace.zoom.us/docs/sdk/native-sdks/android/mastering-zoom-sdk/sdk-initialization
