### PR TITLE
feature/enabled-static-framewrok-for-iOS-in-podspec

### DIFF
--- a/RNZoomUs.podspec
+++ b/RNZoomUs.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.libraries = "sqlite3", "z.1.2.5", "c++"
-
+  s.static_framework = true
   s.dependency "React"
   s.dependency "ZoomSDK" , '5.4.54802.0124.1'
 end


### PR DESCRIPTION
- PR for enabling the static frameworks for iOS in the podspec file