### PR TITLE
Enable webinarToken params in Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,4 @@ buck-out/
 .npmrc
 
 # ignore compiled
-**/*.js
-**/*.d.ts
 !typings/*

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-**/*.ts
-!**/*.d.ts
-scripts
-**/tests
-**/test
-
-docs
-.github

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -193,6 +193,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       if(paramMap.hasKey("noShare")) opts.no_share = paramMap.getBoolean("noShare");
       if(paramMap.hasKey("noTitlebar")) opts.no_titlebar = paramMap.getBoolean("noTitlebar");
       if(paramMap.hasKey("customMeetingId")) opts.custom_meeting_id = paramMap.getString("customMeetingId");
+      if(paramMap.hasKey("webinarToken")) opts.webinar_token = paramMap.getString("webinarToken");
 
       if(paramMap.hasKey("noButtonLeave") && paramMap.getBoolean("noButtonLeave")) opts.meeting_views_options = opts.meeting_views_options + view.NO_BUTTON_LEAVE;
       if(paramMap.hasKey("noButtonMore") && paramMap.getBoolean("noButtonMore")) opts.meeting_views_options = opts.meeting_views_options + view.NO_BUTTON_MORE;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,63 @@
+import { NativeModule } from 'react-native';
+interface RNZoomUsInitializeCommonParams {
+  domain?: string;
+  iosAppGroupId?: string;
+  iosScreenShareExtensionId?: string;
+}
+export interface RNZoomUsInitializeParams extends RNZoomUsInitializeCommonParams {
+  clientKey: string;
+  clientSecret: string;
+}
+export interface RNZoomUsSDKInitParams extends RNZoomUsInitializeCommonParams {
+  jwtToken: string;
+}
+declare function initialize(params: RNZoomUsInitializeParams | RNZoomUsSDKInitParams, settings?: {
+  disableShowVideoPreviewWhenJoinMeeting?: boolean;
+}): Promise<any>;
+export interface RNZoomUsJoinMeetingParams {
+  userName: string;
+  meetingNumber: string | number;
+  password?: string;
+  participantID?: string;
+  autoConnectAudio?: boolean;
+  noAudio?: boolean;
+  noVideo?: boolean;
+  noInvite?: boolean;
+  noBottomToolbar?: boolean;
+  noPhoneDialIn?: boolean;
+  noPhoneDialOut?: boolean;
+  noMeetingEndMessage?: boolean;
+  noMeetingErrorMessage?: boolean;
+  noShare?: boolean;
+  noTitlebar?: boolean;
+  noButtonLeave?: boolean;
+  noButtonMore?: boolean;
+  noButtonParticipants?: boolean;
+  noButtonShare?: boolean;
+  noTextMeetingId?: boolean;
+  noTextPassword?: boolean;
+  zoomAccessToken?: string;
+  webinarToken?: string;
+}
+declare function joinMeeting(params: RNZoomUsJoinMeetingParams): Promise<any>;
+declare function joinMeetingWithPassword(...params: any[]): Promise<any>;
+export interface RNZoomUsStartMeetingParams {
+  userName: string;
+  meetingNumber: string | number;
+  userId: string;
+  userType?: number;
+  zoomAccessToken: string;
+}
+declare function startMeeting(params: RNZoomUsStartMeetingParams): Promise<any>;
+declare function leaveMeeting(): Promise<any>;
+declare function connectAudio(): Promise<any>;
+export declare const ZoomEmitter: NativeModule;
+declare const _default: {
+  initialize: typeof initialize;
+  joinMeeting: typeof joinMeeting;
+  joinMeetingWithPassword: typeof joinMeetingWithPassword;
+  startMeeting: typeof startMeeting;
+  leaveMeeting: typeof leaveMeeting;
+  connectAudio: typeof connectAudio;
+};
+export default _default;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,69 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+  return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ZoomEmitter = void 0;
+const react_native_1 = require("react-native");
+const invariant_1 = __importDefault(require("invariant"));
+const { RNZoomUs } = react_native_1.NativeModules;
+if (!RNZoomUs)
+  console.error('RNZoomUs native module is not linked.');
+const DEFAULT_USER_TYPE = 2;
+async function initialize(params, settings = {
+  // more details inside: https://github.com/mieszko4/react-native-zoom-us/issues/28
+  disableShowVideoPreviewWhenJoinMeeting: true,
+}) {
+  invariant_1.default(typeof params === 'object', 'ZoomUs.initialize expects object param. Consider to check migration docs. ' +
+    'Check Link: https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md');
+  if ('jwtToken' in params) {
+    invariant_1.default(params.jwtToken, 'ZoomUs.initialize requires jwtToken');
+  }
+  else {
+    invariant_1.default(params.clientKey, 'ZoomUs.initialize requires clientKey');
+    invariant_1.default(params.clientSecret, 'ZoomUs.initialize requires clientSecret');
+  }
+  if (!params.domain)
+    params.domain = 'zoom.us';
+  return RNZoomUs.initialize(params, settings);
+}
+async function joinMeeting(params) {
+  let { meetingNumber, noAudio = false, noVideo = false, autoConnectAudio = false } = params;
+  invariant_1.default(meetingNumber, 'ZoomUs.joinMeeting requires meetingNumber');
+  if (typeof meetingNumber !== 'string')
+    meetingNumber = meetingNumber.toString();
+  // without noAudio, noVideo fields SDK can stack on joining meeting room for release build
+  return RNZoomUs.joinMeeting({
+    ...params,
+    meetingNumber,
+    noAudio: !!noAudio,
+    noVideo: !!noVideo,
+    autoConnectAudio,
+  });
+}
+async function joinMeetingWithPassword(...params) {
+  console.warn("ZoomUs.joinMeetingWithPassword is deprecated. Use joinMeeting({ password: 'xxx', ... })");
+  return RNZoomUs.joinMeetingWithPassword(...params);
+}
+async function startMeeting(params) {
+  let { userType = DEFAULT_USER_TYPE, meetingNumber } = params;
+  invariant_1.default(meetingNumber, 'ZoomUs.startMeeting requires meetingNumber');
+  if (typeof meetingNumber !== 'string')
+    meetingNumber = meetingNumber.toString();
+  return RNZoomUs.startMeeting({ userType, ...params, meetingNumber });
+}
+async function leaveMeeting() {
+  return RNZoomUs.leaveMeeting();
+}
+async function connectAudio() {
+  return RNZoomUs.connectAudio();
+}
+exports.ZoomEmitter = RNZoomUs;
+exports.default = {
+  initialize,
+  joinMeeting,
+  joinMeetingWithPassword,
+  startMeeting,
+  leaveMeeting,
+  connectAudio,
+};


### PR DESCRIPTION
In this PR, I made some changes that help me to enable from React Native to pass webinarToken when trying to joining webinar with Zoom SDK in Android.

Please review my changes since it must be helpful to enable joining webinar with the token so user doesn't need to authenticate their account again in Android as well