### PR TITLE
fix crash on initialize

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -55,7 +55,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   private final static String TAG = "RNZoomUs";
   private final ReactApplicationContext reactContext;
 
-  private Boolean isInitialized = false;
   private Boolean shouldAutoConnectAudio = false;
   private Promise initializePromise;
   private Promise meetingPromise;
@@ -77,17 +76,27 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   @ReactMethod
+  public void isInitialized(final Promise promise) {
+    try {
+      ZoomSDK zoomSDK = ZoomSDK.getInstance();
+
+      Boolean isInitialized = zoomSDK.isInitialized();
+      promise.resolve(isInitialized);
+    } catch (Exception ex) {
+      promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+    }
+  }
+
+  @ReactMethod
   public void initialize(final ReadableMap params, final ReadableMap settings, final Promise promise) {
-    if (isInitialized) {
+    ZoomSDK zoomSDK = ZoomSDK.getInstance();
+    if (zoomSDK.isInitialized()) {
       promise.resolve("Already initialize Zoom SDK successfully.");
       return;
     }
-
-    isInitialized = true;
+    initializePromise = promise;
 
     try {
-      initializePromise = promise;
-
       if (settings.hasKey("disableShowVideoPreviewWhenJoinMeeting")) {
         shouldDisablePreview = settings.getBoolean("disableShowVideoPreviewWhenJoinMeeting");
       }
@@ -123,7 +132,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
           }
       });
     } catch (Exception ex) {
-      meetingPromise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+      promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ async function initialize(
     // more details inside: https://github.com/mieszko4/react-native-zoom-us/issues/28
     disableShowVideoPreviewWhenJoinMeeting: true,
   },
-) {
+): Promise<string> {
   invariant(typeof params === 'object',
     'ZoomUs.initialize expects object param. Consider to check migration docs. ' +
     'Check Link: https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md',
@@ -48,6 +48,10 @@ async function initialize(
   if (!params.domain) params.domain = 'zoom.us'
 
   return RNZoomUs.initialize(params, settings)
+}
+
+function isInitialized(): Promise<boolean> {
+  return RNZoomUs.isInitialized()
 }
 
 export interface RNZoomUsJoinMeetingParams {
@@ -202,6 +206,7 @@ export default {
   startMeeting,
   leaveMeeting,
   connectAudio,
+  isInitialized,
   isMeetingHost,
   isMeetingConnected,
   getInMeetingUserIdList,


### PR DESCRIPTION
Fix crash: https://github.com/mieszko4/react-native-zoom-us/issues/98

Extra:
- isInitialized - new method for js (forget to add to IOS)
- removed isInitialized variable, because it is not used by code. Other methods check it from zoomSdk

I tested and it worked ok. Multiple calls of init look ok.

It would be great to add some eslint for ts file. My IDEA inherit it from project and I see whole file in red :)