### PR TITLE
IOS SDK 5.7.1.644

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 
 Android updates:
 - Upgrade android ZoomSDK to 5.7.1.1267
+- Upgrade ios ZoomSDk to 5.7.1.644
 - Delete local archive repository for .arr files
 - `participant_id` param is removed from sdk
+- added `isInitialized()` method
 - `Breaking changes`: Make sure to check https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md#600-jitpack
-
 
 ### 5.12.0
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 This is a bridge for ZoomUS SDK:
 
 | Platform      | Version           | Url                                      | Changelog                                                            |
-| :-----------: | :---------------: | :--------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.5.12511.0421    | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
+| :-----------: | :---------------  | :--------------------------------------: | :------------------------------------------------------------------: |
+| iOS	        | 5.7.1.644         | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
 | Android       | 5.7.1.1267        | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on XCode 12.4 and react-native 0.64.2. ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
@@ -135,7 +135,6 @@ await ZoomUs.joinMeeting({
   userName: 'Johny',
   meetingNumber: '12345678',
   password: '1234',
-  participantID: 'our-unique-id',
   noAudio: true,
   noVideo: true,
 })

--- a/RNZoomUs.podspec
+++ b/RNZoomUs.podspec
@@ -19,6 +19,6 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
   s.dependency "React"
-  s.dependency "ZoomSDK" , '5.5.12511.0421'
+  s.dependency "ZoomSDK", '5.7.1.644'
 end
 

--- a/index.ts
+++ b/index.ts
@@ -58,7 +58,6 @@ export interface RNZoomUsJoinMeetingParams {
   userName: string
   meetingNumber: string | number
   password?: string
-  participantID?: string
   autoConnectAudio?: boolean
   noAudio?: boolean
   noVideo?: boolean

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -43,6 +43,15 @@
 
 RCT_EXPORT_MODULE()
 
+RCT_EXPORT_METHOD(isInitialized: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+  @try {
+    // todo check from ZoomSdk
+    resolve(@(isInitialized));
+  } @catch (NSError *ex) {
+    reject(@"ERR_UNEXPECTED_EXCEPTION", @"Executing isInitialized", ex);
+  }
+}
+
 RCT_EXPORT_METHOD(
   initialize: (NSDictionary *)data
   withSettings: (NSDictionary *)settings
@@ -144,7 +153,7 @@ RCT_EXPORT_METHOD(
       joinParam.userName = data[@"userName"];
       joinParam.meetingNumber = data[@"meetingNumber"];
       joinParam.password =  data[@"password"];
-      joinParam.participantID = data[@"participantID"];
+//       joinParam.participantID = data[@"participantID"]; // todo any new keyword?
       joinParam.zak = data[@"zoomAccessToken"];
       joinParam.webinarToken =  data[@"webinarToken"];
       joinParam.noAudio = data[@"noAudio"];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.0.4",
   "description": "React-native bridge for ZoomUs SDK",
   "homepage": "https://github.com/mieszko4/react-native-zoom-us",
-  "main": "index.js",
+  "main": "index",
   "types": "index.d.ts",
   "scripts": {
     "prepack": "npx tsc --noEmit false",


### PR DESCRIPTION
I don't know why they removed participantID. Field is useful.

I removed extension from main file to make it flexible (to choose between js or ts file)
I use sometimes ts variant when clone project. Also it allows to install library directly from github.

https://github.com/mieszko4/react-native-zoom-us/issues/109