### PR TITLE
Dont unmute audio on connectAudioWithVoIP 

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -742,7 +742,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     final InMeetingAudioController audioController = inMeetingService.getInMeetingAudioController();
 
     audioController.connectAudioWithVoIP();
-    audioController.muteMyAudio(false);
   }
 
   private void registerListener() {


### PR DESCRIPTION
When I initially created this option I unmuted the audio of the user which is not what this should do. It should just connect to audio and keep the audio status untouched as this is part of the meeting settings.