### PR TITLE
Removed unused parameter in stopShareScreen on iOS

### DIFF
--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -360,7 +360,7 @@ RCT_EXPORT_METHOD(startShareScreen: (RCTPromiseResolveBlock)resolve rejecter:(RC
   }
 }
 
-RCT_EXPORT_METHOD(stopShareScreen: (BOOL)muted resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(stopShareScreen: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   @try {
     MobileRTCMeetingService *ms = [[MobileRTC sharedRTC] getMeetingService];
     if (ms) {


### PR DESCRIPTION
* It made the app crash when calling with out the param
* This param is not in line with the android version