### PR TITLE
Fixed issue with screen share events

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -973,26 +973,15 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   public void onFreeMeetingNeedToUpgrade(FreeMeetingNeedUpgradeType type, String gifUrl) {}
 
   // InMeetingShareListener event listeners
+  // DEPRECATED: onShareActiveUser is just kept for now for backwards compatibility of events
   @Override
   public void onShareActiveUser(long userId) {
     final InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
 
-    updateVideoView();
-
     if (inMeetingService.isMyself(userId)) {
       sendEvent("MeetingEvent", "screenShareStarted");
-
-      final InMeetingShareController shareController = inMeetingService.getInMeetingShareController();
-
-      if (shareController.isSharingOut()) {
-        if (shareController.isSharingScreen()) {
-            shareController.startShareScreenContent();
-        }
-      }
     } else if (userId == 0) {
       sendEvent("MeetingEvent", "screenShareStopped");
-    } else {
-      sendEvent("MeetingEvent", "screenShareStartedByUser", userId);
     }
   }
 
@@ -1003,7 +992,22 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   public void onShareUserReceivingStatus(long userId) {}
 
   @Override
-  public void onSharingStatus(SharingStatus status, long userId) {}
+  public void onSharingStatus(SharingStatus status, long userId) {
+    updateVideoView();
+
+    sendEvent("MeetingEvent", getSharingStatusEventName(status), userId);
+
+    if (status.equals(SharingStatus.Sharing_Self_Send_Begin)) {
+      final InMeetingService inMeetingService = ZoomSDK.getInstance().getInMeetingService();
+      final InMeetingShareController shareController = inMeetingService.getInMeetingShareController();
+
+      if (shareController.isSharingOut()) {
+        if (shareController.isSharingScreen()) {
+            shareController.startShareScreenContent();
+        }
+      }
+    }
+  }
 
   // React LifeCycle
   @Override
@@ -1086,6 +1090,19 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     reactContext
         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
         .emit(name, params);
+  }
+
+  private String getSharingStatusEventName(final SharingStatus status) {
+    switch (status) {
+      case SharingStatus.Sharing_Self_Send_Begin: return "screenShareStartedBySelf";
+      case SharingStatus.Sharing_Self_Send_End: return "screenShareStoppedBySelf";
+      case SharingStatus.Sharing_Other_Share_Begin: return "screenShareStartedByUser";
+      case SharingStatus.Sharing_Other_Share_End: return "screenShareStoppedByUser";
+      case SharingStatus.Sharing_View_Other_Sharing: return "screenShareOtherSharing";
+      case SharingStatus.Sharing_Pause: return "screenSharePause";
+      case SharingStatus.Sharing_Resume: return "screenShareResume";
+      default: return "screenShareStoppedByUser";
+    }
   }
 
   private String getAuthErrorName(final int errorCode) {

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1094,13 +1094,13 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   private String getSharingStatusEventName(final SharingStatus status) {
     switch (status) {
-      case SharingStatus.Sharing_Self_Send_Begin: return "screenShareStartedBySelf";
-      case SharingStatus.Sharing_Self_Send_End: return "screenShareStoppedBySelf";
-      case SharingStatus.Sharing_Other_Share_Begin: return "screenShareStartedByUser";
-      case SharingStatus.Sharing_Other_Share_End: return "screenShareStoppedByUser";
-      case SharingStatus.Sharing_View_Other_Sharing: return "screenShareOtherSharing";
-      case SharingStatus.Sharing_Pause: return "screenSharePause";
-      case SharingStatus.Sharing_Resume: return "screenShareResume";
+      case Sharing_Self_Send_Begin: return "screenShareStartedBySelf";
+      case Sharing_Self_Send_End: return "screenShareStoppedBySelf";
+      case Sharing_Other_Share_Begin: return "screenShareStartedByUser";
+      case Sharing_Other_Share_End: return "screenShareStoppedByUser";
+      case Sharing_View_Other_Sharing: return "screenShareOtherSharing";
+      case Sharing_Pause: return "screenSharePause";
+      case Sharing_Resume: return "screenShareResume";
       default: return "screenShareStoppedByUser";
     }
   }

--- a/docs/EVENTS.md
+++ b/docs/EVENTS.md
@@ -104,9 +104,15 @@ zoomEmitter.addListener('MeetingEvent', (meetingEvent) => {
   // {event: 'myVideoStatusChanged', userRole: string, audioType: number, isMutedAudio: boolean, isTalking: boolean, isMutedVideo: boolean}
   
   // Meeting screen share events
-  // {event: 'screenShareStarted'}
-  // {event: 'screenShareStopped'}
+  // {event: 'screenShareStartedBySelf', userId: number}
+  // {event: 'screenShareStoppedBySelf', userId: number}
   // {event: 'screenShareStartedByUser', userId: number}
+  // {event: 'screenShareStoppedByUser', userId: number}
+  // {event: 'screenShareOtherSharing', userId: number}
+  // {event: 'screenSharePause', userId: number}
+  // {event: 'screenShareResume', userId: number}
+  // {event: 'screenShareStarted'} // DEPRECATED
+  // {event: 'screenShareStopped'} // DEPRECATED
   
   
   // ANDROID ONLY EVENTS


### PR DESCRIPTION
Fixed #198 

So we started using the new onSharingStatus event listener, we left the old deprecated onShareActiveUser for backwards compatibility.

* onShareActiveUser has been deprecated
* Im keeping it for now for events backwards compatibility
* I renamed some events following what onSharingStatus gets
* Events added: screenShareStartedBySelf, screenShareStoppedBySelf, screenShareStoppedByUser, screenShareOtherSharing, screenSharePause, screenShareResume
* Every one of this events now also sends the userId
* We might want to remove onShareActiveUser event listener in next major version
* Added new events to docs