### PR TITLE
feat: upgrade Android to 5.10.3 SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 ## Changelog
 
+### 6.9.0
+Android updates:
+- Updated ZoomSDK to 5.10.3.5614
+- Increased compileSdkVersion to 31
+- Increased targetSdkVersion to 31
+- Increased minSdkVersion to 21
+- Increased buildToolsVersion to 30.0.2
+- Added new required listeners
+  - onLocalVideoOrderUpdated(List<Long> localOrderList)
+  - onAllHandsLowered()
+  - onPermissionRequested(String[] permissions)
+  - onChatMsgDeleteNotification(String msgID, ChatMessageDeleteType deleteBy)
+- Changed deprecated listeners in favour of:
+  - onLocalRecordingStatus(RecordingStatus recordingStatus) -> onLocalRecordingStatus(long userId, RecordingStatus recordingStatus)
+  - onUserNameChanged(long userId, String name) -> onUserNamesChanged(List<Long> userList)
+  - onUserNetworkQualityChanged(long userId) -> onSinkMeetingVideoQualityChanged(VideoQuality videoQuality, long userId)
+  - onMeetingCoHostChanged(long userId) -> onMeetingCoHostChange(long userId, boolean isCoHost)
+
 ### 6.7.0
 Android updates:
 - Updated ZoomSDK to 5.9.1.3674

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a bridge for ZoomUS SDK:
 | iOS	        | 5.9.1.2191 | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
 | Android       | 5.10.3.5614 | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
-Tested on XCode 13.2.1 and react-native 0.66.0. ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
+Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
 
 Pull requests are welcome.
 
@@ -195,12 +195,12 @@ await ZoomUs.connectAudio()
 ## Testing
 
 The plugin has been tested for `joinMeeting` using [smoke test procedure](https://github.com/mieszko4/react-native-zoom-us-test#smoke-test-procedure):
-* react-native-zoom-us: 6.5.1
+* react-native-zoom-us: 6.9.0
 * react-native: 0.66.0
-* node: 14.16.0
+* node: 16.15.0
 * macOS: 10.15.5
 * XCode: 12.4
-* android minSdkVersion: 21
+* Android minSdkVersion: 21
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a bridge for ZoomUS SDK:
 | Platform      | Version    | Url                                      | Changelog                                                            |
 | :-----------: |:-----------| :--------------------------------------: | :------------------------------------------------------------------: |
 | iOS	        | 5.9.1.2191 | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
-| Android       | 5.9.1.3674 | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
+| Android       | 5.10.3.5614 | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on XCode 13.2.1 and react-native 0.66.0. ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Then add this to /android/app/src/main/AndroidManifest.xml
   android:networkSecurityConfig="@xml/network_security_config"
 >
 ```
+
+Source: https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/android-meeting-sdk-v5-9-0.
+
 5. Add this to /android/app/src/debug/res/xml/network_security_config.xml
 ```xml
 <?xml version="1.0" encoding="utf-8"?>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a bridge for ZoomUS SDK:
 
 | Platform      | Version    | Url                                      | Changelog                                                            |
 | :-----------: |:-----------| :--------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.9.1.2191 | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
+| iOS	        | 5.9.6.2769 | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
 | Android       | 5.10.3.5614 | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,18 +11,18 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.0.4'
     }
 }
 
 
 android {
     compileSdkVersion 31
-    buildToolsVersion '29.0.2'
+    buildToolsVersion '31.0.0'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 29
+        minSdkVersion 21
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         vectorDrawables.useSupportLibrary = true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,14 +11,14 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.4'
+        classpath 'com.android.tools.build:gradle:4.2.1'
     }
 }
 
 
 android {
     compileSdkVersion 31
-    buildToolsVersion '31.0.0'
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion 21

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
     buildToolsVersion '29.0.2'
 
     defaultConfig {
@@ -46,18 +46,18 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
 
     implementation 'com.google.android.material:material:1.4.0'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.13.3'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.13.3'
-
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.16.1'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.16.1'
+    implementation 'androidx.window:window:1.0.0'
+    implementation 'androidx.window:window-java:1.0.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.0'
+    implementation 'androidx.core:core-ktx:1.7.0'
+    
     // Other Deps (mentioned in docs - not needed)
     /*
     implementation 'androidx.appcompat:appcompat:1.3.1'
-    implementation 'androidx.window:window:1.0.0-alpha06'
-    implementation 'androidx.window:window-java:1.0.0-beta03'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.0'
-    implementation 'androidx.core:core-ktx:1.6.0'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.21'
     */
 
     // Other Deps (not mentioned in docs)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.9.6.4777'
+    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.10.3.5614'
 
     implementation 'com.airbnb.android:lottie:4.0.0'
 

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -875,7 +875,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   @Override
-  public void onMeetingCoHostChanged(long userId) {
+  public void onMeetingCoHostChanged(long userId, boolean isCoHost) {
     sendEvent("MeetingEvent", "coHostChanged", userId);
   }
 
@@ -952,13 +952,13 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onSinkAllowAttendeeChatNotification(int privilege) {}
   @Override
-  public void onUserNameChanged(long userId, String name) {}
+  public void onUserNameChanged(List<Long> userList) {}
   @Override
   public void onInvalidReclaimHostkey() {}
   @Override
   public void onRecordingStatus(RecordingStatus status) {}
   @Override
-  public void onLocalRecordingStatus(RecordingStatus recordingStatus) {}
+  public void onLocalRecordingStatus(long userId, RecordingStatus recordingStatus) {}
   @Override
   public void onClosedCaptionReceived(String message, long senderId) {}
   @Override

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -66,6 +66,9 @@ import us.zoom.sdk.MeetingOptions;
 import us.zoom.sdk.MeetingViewsOptions;
 import us.zoom.sdk.JoinMeetingParams;
 
+import us.zoom.sdk.VideoQuality;
+import us.zoom.sdk.ChatMessageDeleteType;
+
 public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSDKInitializeListener, InMeetingServiceListener, MeetingServiceListener, InMeetingShareController.InMeetingShareListener, LifecycleEventListener {
 
   private final static String TAG = "RNZoomUs";
@@ -875,7 +878,10 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   @Override
-  public void onMeetingCoHostChanged(long userId, boolean isCoHost) {
+  @Deprecated
+  public void onMeetingCoHostChanged(long userId) {}
+  @Override
+  public void onMeetingCoHostChange(long userId, boolean isCoHost) {
     sendEvent("MeetingEvent", "coHostChanged", userId);
   }
 
@@ -934,6 +940,9 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onSpotlightVideoChanged(boolean on) {}
   @Override
+  @Deprecated
+  public void onUserNetworkQualityChanged(long userId) {};
+  @Override
   public void onSinkMeetingVideoQualityChanged(VideoQuality videoQuality, long userId) {}
   @Override
   public void onMicrophoneStatusError(InMeetingAudioController.MobileRTCMicrophoneError error) {}
@@ -952,7 +961,10 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onSinkAllowAttendeeChatNotification(int privilege) {}
   @Override
-  public void onUserNameChanged(List<Long> userList) {}
+  @Deprecated
+  public void onUserNameChanged(long userId, String name) {}
+  @Override
+  public void onUserNamesChanged(List<Long> userList) {}
   @Override
   public void onInvalidReclaimHostkey() {}
   @Override
@@ -971,6 +983,15 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   public void onFreeMeetingUpgradeToGiftFreeTrialStart() {}
   @Override
   public void onFreeMeetingNeedToUpgrade(FreeMeetingNeedUpgradeType type, String gifUrl) {}
+  @Override
+  public void onLocalVideoOrderUpdated(List<Long> localOrderList) {}
+  @Override
+  public void onAllHandsLowered() {};
+  @Override
+  public void onPermissionRequested(String[] permissions) {};
+  @Override
+  public void onChatMsgDeleteNotification(String msgID, ChatMessageDeleteType deleteBy) {};
+
 
   // InMeetingShareListener event listeners
   // DEPRECATED: onShareActiveUser is just kept for now for backwards compatibility of events

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -934,7 +934,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onSpotlightVideoChanged(boolean on) {}
   @Override
-  public void onUserNetworkQualityChanged(long userId) {}
+  public void onSinkMeetingVideoQualityChanged(VideoQuality videoQuality, long userId) {}
   @Override
   public void onMicrophoneStatusError(InMeetingAudioController.MobileRTCMicrophoneError error) {}
   @Override

--- a/docs/LINKING.md
+++ b/docs/LINKING.md
@@ -25,30 +25,30 @@ Note: If you're using proguard copy the contents of this module's android/progua
 
 #### Extra steps for iOS
 
-1. In XCode, in your main project go to `General` tab, expand `Linked Frameworks and Libraries` and add the following libraries:
+1. In Xcode, in your main project go to `General` tab, expand `Linked Frameworks and Libraries` and add the following libraries:
 * `libsqlite3.tbd`
 * `libstdc++.6.0.9.tbd`
 * `libz.1.2.5.tbd`
 
-2. In XCode, in your main project go to `General` tab, expand `Linked Frameworks and Libraries` and add `MobileRTC.framework`:
+2. In Xcode, in your main project go to `General` tab, expand `Linked Frameworks and Libraries` and add `MobileRTC.framework`:
 * choose `Add other...`
 * navigate to `../node_modules/react-native-zoom-us/ios/libs`
 * choose `MobileRTC.framework`
 
-3. In XCode, in your main project go to `General` tab, expand `Embedded Binaries` and add `MobileRTC.framework` from the list - should be at `Frameworks`.
+3. In Xcode, in your main project go to `General` tab, expand `Embedded Binaries` and add `MobileRTC.framework` from the list - should be at `Frameworks`.
 
-4. In XCode, in your main project go to `Build Phases` tab, expand `Copy Bundle Resources` and add `MobileRTCResources.bundle`:
+4. In Xcode, in your main project go to `Build Phases` tab, expand `Copy Bundle Resources` and add `MobileRTCResources.bundle`:
 * choose `Add other...`
 * navigate to `../node_modules/react-native-zoom-us/ios/libs`
 * choose `MobileRTCResources.bundle`
 * choose `Create folder references` and uncheck `Copy files if needed`
 Note: if you do not have `Copy Bundle Resources` you can add it by clicking on top-left `+` sign
 
-5. In XCode, in your main project go to `Build Settings` tab:
+5. In Xcode, in your main project go to `Build Settings` tab:
 * search for `Enable Bitcode` and make sure it is set to `NO`
 * search for `Framework Search Paths` and add `$(SRCROOT)/../node_modules/react-native-zoom-us/ios/libs` with `non-recursive`
 
-6. In XCode, in your main project go to `Info` tab and add the following keys with appropriate description:
+6. In Xcode, in your main project go to `Info` tab and add the following keys with appropriate description:
 * `NSCameraUsageDescription`
 * `NSMicrophoneUsageDescription`
 * `NSPhotoLibraryUsageDescription`
@@ -59,9 +59,9 @@ Note: if you do not have `Copy Bundle Resources` you can add it by clicking on t
 
 #### iOS
 
-1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+1. In Xcode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
 2. Go to `node_modules` ➜ `react-native-zoom-us` and add `RNZoomUs.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNZoomUs.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+3. In Xcode, in the project navigator, select your project. Add `libRNZoomUs.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 5. Follow [Mostly automatic installation-> Extra steps for iOS](#extra-steps-for-ios)
 


### PR DESCRIPTION
Based on changelog:
* https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/meeting-sdk-android-v5-10-1
* https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/meeting-sdk-android-v5-10-3

Possible breaking changes:
* `compileSdkVersion` is `31`
* `buildToolsVersion` is `30.0.2`
* `minSdkVersion` is `21`
* `targetSdkVersion` is `31`

For Android 12 added:
* `android.permission.BLUETOOTH_SCAN`

Closes https://github.com/mieszko4/react-native-zoom-us/issues/201

## Smoke Test Procedure
The following procedure covers testing of the bridge (initialization and join meeting only).

### Android

#### Emulator  (Android 9, x86)
1. [x] Development: `yarn run android`

#### Real Device (Android 11)
1. [x] Development: `yarn run android`
2. [x] Release: `cd android && ./gradlew assembleRelease && cd ..`, `adb install android/app/build/outputs/apk/release/app-release.apk`

### iOS

#### Simulator
1. [x] Development: `yarn run ios`

#### Real Device
Note: You will need to allow to install app; look for: Settings -> General -> Device Management -> Apple Development

1. [ ] Development: Xcode: Product -> Run
2. [ ] Release: Xcode: Product -> Profile
3. [ ] Archive: Xcode: Product -> Archive
