### PR TITLE
Add methods for event subscribing (MeetingStatus group).

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "root": true // needed to disable parent eslint
+}

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 
 # react-native-zoom-us
 
-This is a bridge for ZoomUS SDK:
+This is a bridge for ZoomUS SDK.
 
-| Platform      | Version    | Url                                      | Changelog                                                            |
-| :-----------: |:-----------| :--------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.9.6.2769 | https://github.com/zoom/zoom-sdk-ios     | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
-| Android       | 5.10.3.5614 | https://github.com/zoom/zoom-sdk-android | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
+[![npm](https://img.shields.io/npm/v/react-native-zoom-us)](https://www.npmjs.com/package/react-native-zoom-us)
+
+| Platform      | Version     | SDK Url                                                                      | Changelog                                                            |
+| :-----------: |:------------| :----------------------------------------------------------------------: | :------------------------------------------------------------------: |
+| iOS	        | 5.9.6.2769  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
+| Android       | 5.10.3.5614 | [jitpack-zoom-us](https://github.com/zoom-us-community/jitpack-zoom-us)  | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
 
@@ -16,6 +18,15 @@ Pull requests are welcome.
 - [Upgrading Guide](./docs/UPGRADING.md)
 - [CHANGELOG](./CHANGELOG.md)
 - [TROUBLESHOOTING](./docs/TROUBLESHOOTING.md)
+
+## Docs
+
+- [Screenshare on iOS](docs/IOS-SCREENSHARE.md)
+- [Events](docs/EVENTS.md)
+- [Video View Component](docs/VIDEO-VIEW.md)
+- [Size Reduction](docs/SIZE-REDUCTION-TIPS.md)
+- [Custom Meeting Activity](docs/CUSTOM-MEETING-ACTIVITY.md)
+
 
 ## Getting started
 
@@ -184,13 +195,29 @@ await ZoomUs.connectAudio()
 // you can also use autoConnectAudio: true in `ZoomUs.joinMeeting`
 ```
 
-## Docs
+## Events Api
 
-- [Screenshare on iOS](docs/IOS-SCREENSHARE.md)
-- [Events](docs/EVENTS.md)
-- [Video View Component](docs/VIDEO-VIEW.md)
-- [Size Reduction](docs/SIZE-REDUCTION-TIPS.md)
-- [Custom Meeting Activity](docs/CUSTOM-MEETING-ACTIVITY.md)
+Hook sample for listening events:
+```tsx
+import ZoomUs from 'react-native-zoom-us'
+
+useEffect(() => {
+  const listener = ZoomUs.onMeetingStatusChange(({ event }) => {
+    console.log('onMeetingStatusChange', event)
+  })
+  const joinListener = ZoomUs.onMeetingJoined(() => {
+    console.log('onMeetingJoined')
+  })
+  
+  return () => {
+    listener.remove()
+    joinListener.remove()
+  }
+}, [])
+```
+
+If you need more events, take a look [Events](./docs/EVENTS.md)
+
 
 ## Testing
 

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -736,10 +736,10 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     String errorInfo = getAuthErrorName(errorCode);
     sendEvent("AuthEvent", errorInfo);
     if(errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
-      String errorFormatted = String.format("Error: %d (%s)", errorCode, errorInfo);
+      String errorFormatted = String.format("Error= %d (%s)", errorCode, errorInfo);
       initializePromise.reject(
-              "ERR_ZOOM_INITIALIZATION",
-              "Error= " + errorFormatted + ", internalErrorCode=" + internalErrorCode
+        "ERR_ZOOM_INITIALIZATION",
+         errorFormatted + ", internalErrorCode=" + internalErrorCode
       );
     } else {
       registerListener();

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -763,6 +763,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     updateVideoView();
 
     sendEvent("MeetingEvent", getMeetErrorName(errorCode), meetingStatus);
+    sendEvent("MeetingStatus", meetingStatus.name());
 
     if (meetingPromise == null) {
       return;

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -733,11 +733,13 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onZoomSDKInitializeResult(int errorCode, int internalErrorCode) {
     Log.i(TAG, "onZoomSDKInitializeResult, errorCode=" + errorCode + ", internalErrorCode=" + internalErrorCode);
-    sendEvent("AuthEvent", getAuthErrorName(errorCode));
+    String errorInfo = getAuthErrorName(errorCode);
+    sendEvent("AuthEvent", errorInfo);
     if(errorCode != ZoomError.ZOOM_ERROR_SUCCESS) {
+      String errorFormatted = String.format("Error: %d (%s)", errorCode, errorInfo);
       initializePromise.reject(
               "ERR_ZOOM_INITIALIZATION",
-              "Error: " + errorCode + ", internalErrorCode=" + internalErrorCode
+              "Error= " + errorFormatted + ", internalErrorCode=" + internalErrorCode
       );
     } else {
       registerListener();

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -22,3 +22,5 @@ implementation (project(':react-native-zoom-us')) {
 If lib still not published: `yarn add https://github.com/react-native-video/react-native-video#724b8629f6c7f222c08e60e6948d06fa45a6f4f2`
 
 Note: it can be also with other libs which uses exoplayer
+
+**Note:** Solution can be different for newer versions.

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,7 @@
 import { NativeModule, Platform } from 'react-native'
 import invariant from 'invariant'
 import { RNZoomUs } from './native'
-
-if (!RNZoomUs) console.error('RNZoomUs native module is not linked.')
+import events from './src/events'
 
 const DEFAULT_USER_TYPE = 2
 
@@ -239,10 +238,9 @@ async function lowerMyHand() {
   return RNZoomUs.lowerMyHand()
 }
 
-export const ZoomEmitter = RNZoomUs as NativeModule;
-
 export { default as ZoomUsVideoView } from './video-view'
 
+export * from './src/events'
 export default {
   initialize,
   joinMeeting,
@@ -264,4 +262,5 @@ export default {
   switchCamera,
   raiseMyHand,
   lowerMyHand,
+  ...events,
 }

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -513,6 +513,7 @@ RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
 
   NSString* statusString = [self formatStateToString:state];
   [self sendEventWithName:@"MeetingEvent" event:@"success" status:statusString];
+  [self sendEventWithName:@"MeetingStatus" event:statusString];
 
   if (state == MobileRTCMeetingState_InMeeting && shouldAutoConnectAudio == YES) {
     [self connectAudio];
@@ -730,7 +731,7 @@ RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-  return @[@"AuthEvent", @"MeetingEvent"];
+  return @[@"AuthEvent", @"MeetingEvent", @"MeetingStatus"];
 }
 
 - (void)sendEventWithName:(NSString *)name event:(NSString *)event {

--- a/native.ts
+++ b/native.ts
@@ -41,5 +41,3 @@ export const RNZoomUsVideoView = (
 
 export const RNZoomUs = NativeModules.RNZoomUs
 if (!RNZoomUs) console.error('[react-native-zoom-us] RNZoomUs native module is not linked.')
-
-export default RNZoomUs

--- a/native.ts
+++ b/native.ts
@@ -26,7 +26,7 @@ export interface NativeLayoutUnit {
   showAudioOff?: boolean
   userIndex?: number
   background?: string
-  aspectMode?: VideoAspectModeEnum
+  aspectMode?: VideoAspectModeEnum // buggy typing
 }
 
 export interface NativeVideoProps {
@@ -40,3 +40,6 @@ export const RNZoomUsVideoView = (
 ) as HostComponent<NativeVideoProps> | null
 
 export const RNZoomUs = NativeModules.RNZoomUs
+if (!RNZoomUs) console.error('[react-native-zoom-us] RNZoomUs native module is not linked.')
+
+export default RNZoomUs

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,52 @@
+import { NativeEventEmitter, NativeModule } from 'react-native'
+import { RNZoomUs } from '../native'
+
+export const ZoomEmitter = RNZoomUs as NativeModule
+const EventEmitter = new NativeEventEmitter(ZoomEmitter)
+
+// Android statuses took from https://zoom.github.io/zoom-sdk-android/us/zoom/sdk/MeetingStatus.html#MEETING_STATUS_INMEETING
+type AndroidStatusEvent =
+    | 'MEETING_STATUS_IDLE'
+    | 'MEETING_STATUS_WAITINGFORHOST'
+    | 'MEETING_STATUS_CONNECTING'
+    | 'MEETING_STATUS_INMEETING'
+    | 'MEETING_STATUS_DISCONNECTING'
+    | 'MEETING_STATUS_RECONNECTING'
+    | 'MEETING_STATUS_FAILED'
+    | 'MEETING_STATUS_IN_WAITING_ROOM'
+    | 'MEETING_STATUS_WEBINAR_PROMOTE'
+    | 'MEETING_STATUS_WEBINAR_DEPROMOTE'
+    | 'MEETING_STATUS_UNKNOWN'
+
+// does these extra events exists in android? Maybe different listeners.
+type IOSStatusExtraEvent =
+    | 'MEETING_STATUS_WAITING_EXTERNAL_SESSION_KEY'
+    | 'MEETING_STATUS_ENDED'
+    | 'MEETING_STATUS_LOCKED'
+    | 'MEETING_STATUS_UNLOCKED'
+    | 'MEETING_STATUS_JOIN_BO'
+    | 'MEETING_STATUS_LEAVE_BO'
+
+type IOSStatusEvent = AndroidStatusEvent | IOSStatusExtraEvent
+
+export type ZoomUsMeetingStatusEvent = AndroidStatusEvent | IOSStatusEvent
+
+function onMeetingStatusChange(fn: (data: { event: ZoomUsMeetingStatusEvent }) => any) {
+  return EventEmitter.addListener('MeetingStatus', (data: { event: ZoomUsMeetingStatusEvent }) => {
+    // here we can add extra params, if needed
+    fn(data)
+  })
+}
+
+function onMeetingJoined(fn: () => any) {
+  return onMeetingStatusChange(({ event }) => {
+    if(event === 'MEETING_STATUS_INMEETING') {
+      fn()
+    }
+  })
+}
+
+export default {
+  onMeetingStatusChange,
+  onMeetingJoined,
+}


### PR DESCRIPTION
I want to give some methods with typing for existing events.
I chose only specific group of events for now, which looks good for me: MeetingStatus (ios + android) events.

I made another channel for events for 2 reasons:
1) currently all events are going in 1 channel and it can make confusing behaviour, because there are many events. Most of them can be not normalised.

2) I want to avoid breaking changes for apps that using existing events at the moment.