### PR TITLE
feat: Upgrade iOS to 5.11.0.3907

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 6.12.0
+iOS updates:
+- Updated ZOomSDK to 5.11.0.3907
+
 ### 6.11.0
 iOS updates:
 - Updated ZoomSDK to 5.10.3.3244

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a bridge for ZoomUS SDK.
 
 | Platform      | Version     | SDK Url                                                                      | Changelog                                                            |
 | :-----------: |:------------| :----------------------------------------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.10.3.3244  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
+| iOS	        | 5.11.0.3907  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
 | Android       | 5.10.3.5614 | [jitpack-zoom-us](https://github.com/zoom-us-community/jitpack-zoom-us)  | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))

--- a/RNZoomUs.podspec
+++ b/RNZoomUs.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
   s.dependency "React"
-  s.dependency "ZoomSDK", '5.10.3.3244'
+  s.dependency "ZoomSDK", '5.11.0.3907'
 
 end
 


### PR DESCRIPTION
Based on changelog:

* https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/meeting-sdk-v5-10-3-patch
* https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/meeting-sdk-ios-v5-10-6
* https://8xmdmkir8ctlkfj8dttx.noticeable.news/publications/meeting-sdk-ios-v5-11-0

## Smoke Test Procedure
The following procedure covers testing of the bridge (initialization and join meeting only).

### Android

#### Emulator
1. [ ] Development: `yarn run android`

#### Real Device
1. [ ] Development: `yarn run android`
2. [ ] Release: `cd android && ./gradlew assembleRelease && cd ..`, `adb install android/app/build/outputs/apk/release/app-release.apk`

### iOS

#### Simulator
1. [ ] Development: `yarn run ios` (Note that M1 chip is not supported by Zoom SDK)

#### Real Device
Note: You will need to allow to install app; look for: Settings -> General -> Device Management -> Apple Development

1. [x] Development: Xcode: Product -> Run
2. [x] Release: Xcode: Product -> Profile
3. [x] Archive: Xcode: Product -> Archive