### PR TITLE
feat: prepapare android for 5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ iOS updates:
 - Changed deprecated listeners in favour of:
   - (void)onSinkUserNameChanged:(NSUInteger)userID userName:(NSString *_Nonnull)userName -> (void)onSinkUserNameChanged:(NSArray <NSNumber*>* _Nullable)userNameChangedArr
   - (void)onMeetingCoHostChange:(NSUInteger)userId -> (void)onMeetingCoHostChange:(NSUInteger)userId isCoHost:(BOOL)isCoHost
+Android updates:
+- Add more logs
+- Clean up passing initializePromise and meetingPromise, clean up to use only one initialize() call, use reactContext.getCurrentActivity()
+- Wrap methods in try/catch
+- Make sure to execute ZoomSDK on the main thread only
+- Make `leaveMeeting` return promise
+- Add `noMeetingErrorMessage` to `startMeeting` params
+- On destroy unregister listeners and leave meeting
+- On foreground register listeners and return to the meeting
 
 ### 6.9.0
 Android updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,6 @@
 ## Changelog
 
-### 6.12.0
-iOS updates:
-- Updated ZOomSDK to 5.11.0.3907
-
-### 6.11.0
-iOS updates:
-- Updated ZoomSDK to 5.10.3.3244
-- Changed deprecated listeners in favour of:
-  - (void)onSinkUserNameChanged:(NSUInteger)userID userName:(NSString *_Nonnull)userName -> (void)onSinkUserNameChanged:(NSArray <NSNumber*>* _Nullable)userNameChangedArr
-  - (void)onMeetingCoHostChange:(NSUInteger)userId -> (void)onMeetingCoHostChange:(NSUInteger)userId isCoHost:(BOOL)isCoHost
+### 6.13.0
 Android updates:
 - Add more logs
 - Clean up passing initializePromise and meetingPromise, clean up to use only one initialize() call, use reactContext.getCurrentActivity()
@@ -19,6 +10,17 @@ Android updates:
 - Add `noMeetingErrorMessage` to `startMeeting` params
 - On destroy unregister listeners and leave meeting
 - On foreground register listeners and return to the meeting
+
+### 6.12.0
+iOS updates:
+- Updated ZoomSDK to 5.11.0.3907
+
+### 6.11.0
+iOS updates:
+- Updated ZoomSDK to 5.10.3.3244
+- Changed deprecated listeners in favour of:
+  - (void)onSinkUserNameChanged:(NSUInteger)userID userName:(NSString *_Nonnull)userName -> (void)onSinkUserNameChanged:(NSArray <NSNumber*>* _Nullable)userNameChangedArr
+  - (void)onMeetingCoHostChange:(NSUInteger)userId -> (void)onMeetingCoHostChange:(NSUInteger)userId isCoHost:(BOOL)isCoHost
 
 ### 6.9.0
 Android updates:

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -797,14 +797,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       return;
     }
 
-    UiThreadUtil.runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
         final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
-
         audioController.connectAudioWithVoIP();
-      }
-    });
   }
 
   private void registerListener() {

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -151,8 +151,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
           ZoomSDK zoomSDK = ZoomSDK.getInstance();
           if (zoomSDK.isInitialized()) {
-            promise.resolve("Already initialize Zoom SDK successfully.");
-
             // Apply fresh settings
             final MeetingSettingsHelper meetingSettingsHelper = ZoomSDK.getInstance().getMeetingSettingsHelper();
             if (meetingSettingsHelper != null) {
@@ -160,6 +158,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
               meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
             }
 
+            promise.resolve("Already initialize Zoom SDK successfully.");
             return;
           }
 

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1167,6 +1167,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
             Log.i(TAG, "onHostResume, returning to meeting");
             meetingService.returnToMeeting(reactContext.getCurrentActivity());
           }
+
+          registerListener();
         } catch (Exception ex) {
           Log.e(TAG, ex.getMessage());
         }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -88,7 +88,16 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
       if (requestCode == SCREEN_SHARE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
-        startZoomScreenShare(intent);
+        UiThreadUtil.runOnUiThread(new Runnable() {
+          @Override
+          public void run() {
+            try {
+              startZoomScreenShare(intent);
+            } catch (Exception ex) {
+              Log.e(TAG, ex.getMessage());
+            }
+          }
+        });
       }
     }
   };
@@ -581,21 +590,16 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   private void startZoomScreenShare(final Intent intent) {
-    UiThreadUtil.runOnUiThread(new Runnable() {
-      @Override
-      public void run() {
-        final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-        final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
+    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+    final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
 
-        MobileRTCSDKError result = shareController.startShareScreenSession(intent);
+    MobileRTCSDKError result = shareController.startShareScreenSession(intent);
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          sendEvent("MeetingEvent", "screenShareSuccess");
-        } else {
-          sendEvent("MeetingEvent", "screenShareError", result);
-        }
-      }
-    });
+    if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+      sendEvent("MeetingEvent", "screenShareSuccess");
+    } else {
+      sendEvent("MeetingEvent", "screenShareError", result);
+    }
   }
 
   @ReactMethod

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -119,6 +119,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void initialize(final ReadableMap params, final ReadableMap settings, final Promise promise) {
+    Log.i(TAG, "initialize");
     ZoomSDK zoomSDK = ZoomSDK.getInstance();
     if (zoomSDK.isInitialized()) {
       promise.resolve("Already initialize Zoom SDK successfully.");
@@ -715,6 +716,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
         @Override
         public void execute(NativeViewHierarchyManager nativeViewHierarchyManager) {
           synchronized (videoViews) {
+            Log.i(TAG, "updateVideoView");
             Iterator<Integer> iterator = videoViews.iterator();
             while (iterator.hasNext()) {
               final int tagId = iterator.next();
@@ -754,8 +756,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   @Override
-  public void onZoomAuthIdentityExpired(){
-  }
+  public void onZoomAuthIdentityExpired() {}
 
   // MeetingServiceListener
   @Override
@@ -768,6 +769,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     sendEvent("MeetingStatus", meetingStatus.name());
 
     if (meetingPromise == null) {
+      Log.i(TAG, "onMeetingStatusChanged, does not have meetingPromise");
       return;
     }
 
@@ -810,13 +812,16 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     ZoomSDK zoomSDK = ZoomSDK.getInstance();
     MeetingService meetingService = zoomSDK.getMeetingService();
     if(meetingService != null) {
+      Log.i(TAG, "registerListener, added listener for meetingService");
       meetingService.addListener(this);
     }
     InMeetingService inMeetingService = zoomSDK.getInMeetingService();
     if (inMeetingService != null) {
+      Log.i(TAG, "registerListener, added listener for inMeetingService");
       inMeetingService.addListener(this);
       InMeetingShareController inMeetingShareController = inMeetingService.getInMeetingShareController();
       if (inMeetingShareController != null) {
+        Log.i(TAG, "registerListener, added listener for getInMeetingShareController");
         inMeetingShareController.addListener(this);
       }
     }
@@ -828,13 +833,16 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     if(zoomSDK.isInitialized()) {
       final MeetingService meetingService = zoomSDK.getMeetingService();
       if (meetingService != null) {
+        Log.i(TAG, "unregisterListener, removed listener from meetingService");
         meetingService.removeListener(this);
       }
       final InMeetingService inMeetingService = zoomSDK.getInMeetingService();
       if (inMeetingService != null) {
+        Log.i(TAG, "unregisterListener, removed listener from inMeetingService");
         inMeetingService.removeListener(this);
         final InMeetingShareController inMeetingShareController = inMeetingService.getInMeetingShareController();
         if (inMeetingShareController != null) {
+          Log.i(TAG, "unregisterListener, removed listener from inMeetingShareController");
           inMeetingShareController.removeListener(this);
         }
       }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -633,7 +633,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
           if (customizedMeetingUIEnabled) {
             final MediaProjectionManager manager =
-              (MediaProjectionManager) getReactApplicationContext().getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+              (MediaProjectionManager) reactContext.getCurrentActivity().getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
             if (manager != null) {
               Intent intent = manager.createScreenCaptureIntent();

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -77,7 +77,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   private final static int SCREEN_SHARE_REQUEST_CODE = 99;
   private final ReactApplicationContext reactContext;
 
-  private Boolean shouldAutoConnectAudio = false;
+  private Boolean shouldAutoConnectAudio;
   private Promise initializePromise;
   private Promise meetingPromise;
 
@@ -279,16 +279,13 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     final ReadableMap paramMap,
     Promise promise
   ) {
-    meetingPromise = promise;
-    shouldAutoConnectAudio = paramMap.getBoolean("autoConnectAudio");
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
         try {
           ZoomSDK zoomSDK = ZoomSDK.getInstance();
           if(!zoomSDK.isInitialized()) {
-            meetingPromise.reject("ERR_ZOOM_JOIN", "ZoomSDK has not been initialized successfully");
+            promise.reject("ERR_ZOOM_JOIN", "ZoomSDK has not been initialized successfully");
             return;
           }
 
@@ -342,14 +339,24 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
           if(paramMap.hasKey("password")) params.password = paramMap.getString("password");
           if(paramMap.hasKey("webinarToken")) params.webinarToken = paramMap.getString("webinarToken");
 
+          // Save promise and shouldAutoConnectAudio so that it can be resolved in onMeetingStatusChanged
+          // after zoomSDK.joinMeetingWithParams is called
+          meetingPromise = promise;
+          shouldAutoConnectAudio = paramMap.getBoolean("autoConnectAudio");
           int joinMeetingResult = meetingService.joinMeetingWithParams(reactContext.getCurrentActivity(), params, opts);
           Log.i(TAG, "joinMeeting, joinMeetingResult=" + joinMeetingResult);
 
           if (joinMeetingResult != MeetingError.MEETING_ERROR_SUCCESS) {
+            // We are resolving promise: (1) right away and (2) in onMeetingStatusChanged because in case of no success onMeetingStatusChanged will not be triggered
+            // It is not clear from docs (https://marketplace.zoom.us/docs/sdk/native-sdks/android/mastering-zoom-sdk/start-join-meeting/join-meeting)
             meetingPromise.reject("ERR_ZOOM_JOIN", "joinMeeting, errorCode=" + joinMeetingResult);
+            meetingPromise = null;
+            shouldAutoConnectAudio = null;
           }
         } catch (Exception ex) {
-          meetingPromise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+          meetingPromise = null;
+          shouldAutoConnectAudio = null;
         }
       }
     });
@@ -787,14 +794,16 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
               "Error: " + errorCode + ", internalErrorCode=" + internalErrorCode
       );
       meetingPromise = null;
+
       shouldAutoConnectAudio = null;
     } else if (meetingStatus == MeetingStatus.MEETING_STATUS_INMEETING) {
       meetingPromise.resolve("Connected to zoom meeting");
       meetingPromise = null;
 
-      if (shouldAutoConnectAudio == true) {
+      if (shouldAutoConnectAudio != null && shouldAutoConnectAudio == true) {
         connectAudioWithVoIP();
       }
+      shouldAutoConnectAudio = null;
     }
   }
 

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -938,11 +938,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     }
   }
 
-  @Override
-  public void onCatalystInstanceDestroy() {
-    unregisterListener();
-  }
-
   // InMeetingServiceListener required listeners
   @Override
   public void onMeetingLeaveComplete(long ret) {
@@ -1133,12 +1128,46 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   // React LifeCycle
   @Override
   public void onHostDestroy() {
-    unregisterListener();
+    Log.i(TAG, "onHostDestroy");
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+          if (zoomSDK.isInitialized()) {
+            zoomSDK.getMeetingService().leaveCurrentMeeting(false);
+          }
+
+          unregisterListener();
+        } catch (Exception ex) {
+          Log.e(TAG, ex.getMessage());
+        }
+      }
+    });
   }
   @Override
   public void onHostPause() {}
   @Override
   public void onHostResume() {}
+  @Override
+  public void onCatalystInstanceDestroy() {
+    Log.i(TAG, "onCatalystInstanceDestroy");
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+          if (zoomSDK.isInitialized()) {
+            zoomSDK.getMeetingService().leaveCurrentMeeting(false);
+          }
+
+          unregisterListener();
+        } catch (Exception ex) {
+          Log.e(TAG, ex.getMessage());
+        }
+      }
+    });
+  }
 
   // React Native event emitters and event handling
   private void sendEvent(String name, String event) {

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -369,17 +369,23 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   }
 
   @ReactMethod
-  public void leaveMeeting() {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      return;
-    }
-
+  public void leaveMeeting(Promise promise) {
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        zoomSDK.getMeetingService().leaveCurrentMeeting(false);
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+
+          if (!zoomSDK.isInitialized()) {
+            promise.resolve(null);
+            return;
+          }
+
+          zoomSDK.getMeetingService().leaveCurrentMeeting(false);
+          promise.resolve(null);
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+        }
       }
     });
   }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -244,6 +244,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
           if(paramMap.hasKey("noInvite")) opts.no_invite = paramMap.getBoolean("noInvite");
           if(paramMap.hasKey("noShare")) opts.no_share = paramMap.getBoolean("noShare");
+          if(paramMap.hasKey("noMeetingErrorMessage")) opts.no_meeting_error_message = paramMap.getBoolean("noMeetingErrorMessage");
 
           if(paramMap.hasKey("noButtonLeave") && paramMap.getBoolean("noButtonLeave")) opts.meeting_views_options = opts.meeting_views_options + view.NO_BUTTON_LEAVE;
           if(paramMap.hasKey("noButtonMore") && paramMap.getBoolean("noButtonMore")) opts.meeting_views_options = opts.meeting_views_options + view.NO_BUTTON_MORE;

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -392,88 +392,113 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void connectAudio(Promise promise) {
-    connectAudioWithVoIP();
-    promise.resolve(null);
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          connectAudioWithVoIP();
+          promise.resolve(null);
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+        }
+      }
+    });
   }
 
   @ReactMethod
   public void isMeetingConnected(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.resolve(false);
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        promise.resolve(zoomSDK.getInMeetingService().isMeetingConnected());
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+
+          if (!zoomSDK.isInitialized()) {
+            promise.resolve(false);
+            return;
+          }
+
+          promise.resolve(zoomSDK.getInMeetingService().isMeetingConnected());
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+        }
       }
     });
   }
 
   @ReactMethod
   public void isMeetingHost(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        promise.resolve(zoomSDK.getInMeetingService().isMeetingHost());
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
+
+          promise.resolve(zoomSDK.getInMeetingService().isMeetingHost());
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+        }
       }
     });
   }
 
   @ReactMethod
   public void getInMeetingUserIdList(final Promise promise) {
-    final WritableArray rnUserList = Arguments.createArray();
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.resolve(rnUserList);
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final List<Long> userList = zoomSDK.getInMeetingService().getInMeetingUserList();
+        try {
+          final WritableArray rnUserList = Arguments.createArray();
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        for (final Long userId : userList) {
-          rnUserList.pushString(userId.toString());
+          if (!zoomSDK.isInitialized()) {
+            promise.resolve(rnUserList);
+            return;
+          }
+
+          final List<Long> userList = zoomSDK.getInMeetingService().getInMeetingUserList();
+
+          for (final Long userId : userList) {
+            rnUserList.pushString(userId.toString());
+          }
+
+          promise.resolve(rnUserList);
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
-
-        promise.resolve(rnUserList);
       }
     });
   }
 
   @ReactMethod
   public void muteMyVideo(final boolean muted, final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = videoController.muteMyVideo(muted);
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute my video error, status: " + result.name());
+          final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+
+          MobileRTCSDKError result = videoController.muteMyVideo(muted);
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute my video error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -481,22 +506,26 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void rotateMyVideo(final int rotation, final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        if (videoController.rotateMyVideo(rotation)) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Error: Rotate video failed");
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
+
+          final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+
+          if (videoController.rotateMyVideo(rotation)) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Error: Rotate video failed");
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -504,24 +533,28 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void muteMyAudio(final boolean muted, final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = audioController.muteMyAudio(muted);
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute my audio error, status: " + result.name());
+          final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+
+          MobileRTCSDKError result = audioController.muteMyAudio(muted);
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute my audio error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -529,24 +562,28 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void muteAttendee(final String userId, final boolean muted, final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = audioController.muteAttendeeAudio(muted, Long.parseLong(userId));
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute attendee audio error, status: " + result.name());
+          final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+
+          MobileRTCSDKError result = audioController.muteAttendeeAudio(muted, Long.parseLong(userId));
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute attendee audio error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -554,24 +591,28 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void muteAllAttendee(final boolean allowUnmuteSelf, final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = audioController.muteAllAttendeeAudio(allowUnmuteSelf);
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute all error, status: " + result.name());
+          final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+
+          MobileRTCSDKError result = audioController.muteAllAttendeeAudio(allowUnmuteSelf);
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Mute all error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -579,35 +620,44 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void startShareScreen(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-    if (customizedMeetingUIEnabled) {
-      final MediaProjectionManager manager =
-        (MediaProjectionManager) getReactApplicationContext().getSystemService(Context.MEDIA_PROJECTION_SERVICE);
+          if (customizedMeetingUIEnabled) {
+            final MediaProjectionManager manager =
+              (MediaProjectionManager) getReactApplicationContext().getSystemService(Context.MEDIA_PROJECTION_SERVICE);
 
-      if (manager != null) {
-        Intent intent = manager.createScreenCaptureIntent();
+            if (manager != null) {
+              Intent intent = manager.createScreenCaptureIntent();
 
-        reactContext.getCurrentActivity().startActivityForResult(intent, SCREEN_SHARE_REQUEST_CODE);
+              reactContext.getCurrentActivity().startActivityForResult(intent, SCREEN_SHARE_REQUEST_CODE);
+            }
+
+            promise.resolve(null);
+          } else {
+            final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
+
+            MobileRTCSDKError result = shareController.startShareScreenContent();
+
+            if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+              promise.resolve(null);
+            } else {
+              promise.reject("ERR_ZOOM_MEETING_CONTROL", "Start share screen error, status: " + result.name());
+            }
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+        }
       }
-
-      promise.resolve(null);
-    } else {
-      final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
-
-      MobileRTCSDKError result = shareController.startShareScreenContent();
-
-      if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-        promise.resolve(null);
-      } else {
-        promise.reject("ERR_ZOOM_MEETING_CONTROL", "Start share screen error, status: " + result.name());
-      }
-    }
+    });
   }
 
   private void startZoomScreenShare(final Intent intent) {
@@ -625,24 +675,28 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void stopShareScreen(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = shareController.stopShareScreen();
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Stop share screen error, status: " + result.name());
+          final InMeetingShareController shareController = zoomSDK.getInMeetingService().getInMeetingShareController();
+
+          MobileRTCSDKError result = shareController.stopShareScreen();
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Stop share screen error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -650,27 +704,31 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void switchCamera(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        if (!videoController.isMyVideoMuted()) {
-          if (videoController.switchToNextCamera()) {
-            updateVideoView();
-            promise.resolve(null);
-          } else {
-            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Switch camera failed");
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
           }
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "The camera is muted");
+
+          final InMeetingVideoController videoController = zoomSDK.getInMeetingService().getInMeetingVideoController();
+
+          if (!videoController.isMyVideoMuted()) {
+            if (videoController.switchToNextCamera()) {
+              updateVideoView();
+              promise.resolve(null);
+            } else {
+              promise.reject("ERR_ZOOM_MEETING_CONTROL", "Switch camera failed");
+            }
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "The camera is muted");
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -678,22 +736,26 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void raiseMyHand(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        MobileRTCSDKError result = zoomSDK.getInMeetingService().raiseMyHand();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Raise hand error, status: " + result.name());
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
+
+          MobileRTCSDKError result = zoomSDK.getInMeetingService().raiseMyHand();
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Raise hand error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });
@@ -701,24 +763,28 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   @ReactMethod
   public void lowerMyHand(final Promise promise) {
-    final ZoomSDK zoomSDK = ZoomSDK.getInstance();
-
-    if (!zoomSDK.isInitialized()) {
-      promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
-      return;
-    }
-
     UiThreadUtil.runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        final InMeetingService inMeetingService = zoomSDK.getInMeetingService();
+        try {
+          final ZoomSDK zoomSDK = ZoomSDK.getInstance();
 
-        MobileRTCSDKError result = inMeetingService.lowerHand(inMeetingService.getMyUserID());
+          if (!zoomSDK.isInitialized()) {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "ZoomSDK has not been initialized successfully");
+            return;
+          }
 
-        if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
-          promise.resolve(null);
-        } else {
-          promise.reject("ERR_ZOOM_MEETING_CONTROL", "Lower hand error, status: " + result.name());
+          final InMeetingService inMeetingService = zoomSDK.getInMeetingService();
+
+          MobileRTCSDKError result = inMeetingService.lowerHand(inMeetingService.getMyUserID());
+
+          if (result == MobileRTCSDKError.SDKERR_SUCCESS) {
+            promise.resolve(null);
+          } else {
+            promise.reject("ERR_ZOOM_MEETING_CONTROL", "Lower hand error, status: " + result.name());
+          }
+        } catch (Exception ex) {
+          promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
         }
       }
     });

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1163,7 +1163,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
           }
 
           final MeetingService meetingService = zoomSDK.getMeetingService();
-          if(meetingService.getMeetingStatus() == MeetingStatus.MEETING_STATUS_INMEETING) {
+          if(meetingService.getMeetingStatus() != MeetingStatus.MEETING_STATUS_IDLE ) {
             Log.i(TAG, "onHostResume, returning to meeting");
             meetingService.returnToMeeting(reactContext.getCurrentActivity());
           }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1146,9 +1146,33 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     });
   }
   @Override
-  public void onHostPause() {}
+  public void onHostPause() {
+    Log.i(TAG, "onHostPause");
+  }
   @Override
-  public void onHostResume() {}
+  public void onHostResume() {
+    Log.i(TAG, "onHostResume");
+
+    UiThreadUtil.runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          ZoomSDK zoomSDK = ZoomSDK.getInstance();
+          if(!zoomSDK.isInitialized()) {
+            return;
+          }
+
+          final MeetingService meetingService = zoomSDK.getMeetingService();
+          if(meetingService.getMeetingStatus() == MeetingStatus.MEETING_STATUS_INMEETING) {
+            Log.i(TAG, "onHostResume, returning to meeting");
+            meetingService.returnToMeeting(reactContext.getCurrentActivity());
+          }
+        } catch (Exception ex) {
+          Log.e(TAG, ex.getMessage());
+        }
+      }
+    });
+  }
   @Override
   public void onCatalystInstanceDestroy() {
     Log.i(TAG, "onCatalystInstanceDestroy");

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -69,6 +69,8 @@ import us.zoom.sdk.JoinMeetingParams;
 import us.zoom.sdk.VideoQuality;
 import us.zoom.sdk.ChatMessageDeleteType;
 
+// Please note that SDK initialization and all API call must run in Main Thread.
+// See https://marketplace.zoom.us/docs/sdk/native-sdks/android/mastering-zoom-sdk/sdk-initialization/
 public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSDKInitializeListener, InMeetingServiceListener, MeetingServiceListener, InMeetingShareController.InMeetingShareListener, LifecycleEventListener {
 
   private final static String TAG = "RNZoomUs";
@@ -188,8 +190,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     try {
       videoViews.add(new Integer(tagId));
       promise.resolve(null);
-    } catch (Exception e) {
-      promise.reject("ERR_ZOOM_VIDEO_VIEW", e.toString());
+    } catch (Exception ex) {
+      promise.reject("ERR_ZOOM_VIDEO_VIEW", ex.toString());
     }
   }
 
@@ -198,8 +200,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     try {
       videoViews.remove(new Integer(tagId));
       promise.resolve(null);
-    } catch (Exception e) {
-      promise.reject("ERR_ZOOM_VIDEO_VIEW", e.toString());
+    } catch (Exception ex) {
+      promise.reject("ERR_ZOOM_VIDEO_VIEW", ex.toString());
     }
   }
 
@@ -727,8 +729,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
               try {
                 final RNZoomUsVideoView view = (RNZoomUsVideoView) nativeViewHierarchyManager.resolveView(tagId);
                 if (view != null) view.update();
-              } catch (Exception e) {
-                Log.e(TAG, e.getMessage());
+              } catch (Exception ex) {
+                Log.e(TAG, ex.getMessage());
               }
             }
           }
@@ -803,8 +805,8 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       return;
     }
 
-        final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
-        audioController.connectAudioWithVoIP();
+    final InMeetingAudioController audioController = zoomSDK.getInMeetingService().getInMeetingAudioController();
+    audioController.connectAudioWithVoIP();
   }
 
   private void registerListener() {

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -140,11 +140,6 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       public void run() {
         try {
           Log.i(TAG, "initialize");
-          ZoomSDK zoomSDK = ZoomSDK.getInstance();
-          if (zoomSDK.isInitialized()) {
-            promise.resolve("Already initialize Zoom SDK successfully.");
-            return;
-          }
 
           if (settings.hasKey("disableShowVideoPreviewWhenJoinMeeting")) {
             shouldDisablePreview = settings.getBoolean("disableShowVideoPreviewWhenJoinMeeting");
@@ -152,6 +147,20 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
           if (settings.hasKey("enableCustomizedMeetingUI")) {
             customizedMeetingUIEnabled = settings.getBoolean("enableCustomizedMeetingUI");
+          }
+
+          ZoomSDK zoomSDK = ZoomSDK.getInstance();
+          if (zoomSDK.isInitialized()) {
+            promise.resolve("Already initialize Zoom SDK successfully.");
+
+            // Apply fresh settings
+            final MeetingSettingsHelper meetingSettingsHelper = ZoomSDK.getInstance().getMeetingSettingsHelper();
+            if (meetingSettingsHelper != null) {
+              meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
+              meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
+            }
+
+            return;
           }
 
           String[] parts = settings.getString("language").split("-");

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsVideoView.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsVideoView.java
@@ -87,7 +87,7 @@ class RNZoomUsVideoView extends MobileRTCVideoView {
     }
     MobileRTCVideoViewManager manager = getVideoViewManager();
     if (manager == null) {
-      Log.e(TAG, "The video view is not initialized complately");
+      Log.e(TAG, "The video view is not initialized completely");
       return;
     }
     try {

--- a/index.ts
+++ b/index.ts
@@ -157,6 +157,7 @@ export interface RNZoomUsStartMeetingParams {
   // android only fields:
   noInvite?: boolean
   noShare?: boolean
+  noMeetingErrorMessage?: boolean
 
   noButtonLeave?: boolean
   noButtonMore?: boolean


### PR DESCRIPTION
ZoomSDK for Android complaints about code not being executed on main thread - this PR makes sure to execute ZoomSDK code on main thread, id adds logs, try/catch, cleans up logic.
It also fixes issues with not showing meeting and lost listeners after backgrounding then foregrounding the app.
Finally it adds `noMeetingErrorMessage` to `startMeeting` params.

Closes https://github.com/mieszko4/react-native-zoom-us/issues/192
Closes https://github.com/mieszko4/react-native-zoom-us/issues/166
Hopefully closes  https://github.com/mieszko4/react-native-zoom-us/issues/162

## Smoke Test Procedure
The following procedure covers testing of the bridge (initialization and join meeting only).

### Android

#### Emulator
1. [x] Development: `yarn run android`

#### Real Device
1. [x] Development: `yarn run android`
2. [x] Release: `cd android && ./gradlew assembleRelease && cd ..`, `adb install android/app/build/outputs/apk/release/app-release.apk`

### iOS

#### Simulator
1. [ ] Development: `yarn run ios` (Note that M1 chip is not supported by Zoom SDK)

#### Real Device
Note: You will need to allow to install app; look for: Settings -> General -> Device Management -> Apple Development

1. [ ] Development: Xcode: Product -> Run
2. [ ] Release: Xcode: Product -> Profile
3. [ ] Archive: Xcode: Product -> Archive