### PR TITLE
IOS 5.11.3.4099

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a bridge for ZoomUS SDK.
 
 | Platform      | Version     | SDK Url                                                                      | Changelog                                                            |
 | :-----------: |:------------| :----------------------------------------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.11.0.3907  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
+| iOS	        | 5.11.3.4099  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
 | Android       | 5.10.3.5614 | [jitpack-zoom-us](https://github.com/zoom-us-community/jitpack-zoom-us)  | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
 
 Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))

--- a/RNZoomUs.podspec
+++ b/RNZoomUs.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
   s.dependency "React"
-  s.dependency "ZoomSDK", '5.11.0.3907'
+  s.dependency "ZoomSDK", '5.11.3.4099'
 
 end
 


### PR DESCRIPTION
Looks like there is no breaking changed for native side.

I made minimal test by creating meeting. Works ok.

Should help for: https://github.com/mieszko4/react-native-zoom-us/issues/224