### PR TITLE
IOS SDK 5.11.3.4099.1

### DIFF
--- a/RNZoomUs.podspec
+++ b/RNZoomUs.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
   s.static_framework = true
   s.dependency "React"
-  s.dependency "ZoomSDK", '5.11.3.4099'
+  s.dependency "ZoomSDK", '5.11.3.4099.1'
 
 end
 


### PR DESCRIPTION
Should fix issue mentioned at https://github.com/mieszko4/react-native-zoom-us/issues/224#issuecomment-1210423211
I made minimal test with joining meeting.

Btw. I also republished previous sdk `5.11.3.4099` with correct version, so potentially issue will be solved. But I think it is better to bump version, to avoid cache issues.