### PR TITLE
feat: add props to InitializeSettings

### DIFF
--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -83,7 +83,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   private Boolean shouldDisablePreview = false;
   private Boolean customizedMeetingUIEnabled = false;
-  private Boolean shouldDisableWebKitCacheClear = false;
+  private Boolean disableClearWebKitCache = false;
 
   private List<Integer> videoViews = Collections.synchronizedList(new ArrayList<Integer>());
 
@@ -151,7 +151,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
           }
 
           if (settings.hasKey("disableClearWebKitCache")) {
-            shouldDisableWebKitCacheClear = settings.getBoolean("disableClearWebKitCache");
+            disableClearWebKitCache = settings.getBoolean("disableClearWebKitCache");
           }
 
           ZoomSDK zoomSDK = ZoomSDK.getInstance();
@@ -163,7 +163,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
             if (meetingSettingsHelper != null) {
               meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
               meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
-              meetingSettingsHelper.disableClearWebKitCache(shouldDisableWebKitCacheClear);
+              meetingSettingsHelper.disableClearWebKitCache(disableClearWebKitCache);
             }
 
             promise.resolve("Already initialize Zoom SDK successfully.");
@@ -861,7 +861,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       if (meetingSettingsHelper != null) {
         meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
         meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
-        meetingSettingsHelper.disableClearWebKitCache(shouldDisableWebKitCacheClear);
+        meetingSettingsHelper.disableClearWebKitCache(disableClearWebKitCache);
       }
     }
   }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -83,6 +83,7 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
 
   private Boolean shouldDisablePreview = false;
   private Boolean customizedMeetingUIEnabled = false;
+  private Boolean shouldDisableWebKitCacheClear = false;
 
   private List<Integer> videoViews = Collections.synchronizedList(new ArrayList<Integer>());
 
@@ -149,13 +150,20 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
             customizedMeetingUIEnabled = settings.getBoolean("enableCustomizedMeetingUI");
           }
 
+          if (settings.hasKey("disableClearWebKitCache")) {
+            shouldDisableWebKitCacheClear = settings.getBoolean("disableClearWebKitCache");
+          }
+
           ZoomSDK zoomSDK = ZoomSDK.getInstance();
           if (zoomSDK.isInitialized()) {
             // Apply fresh settings
+
+            // This setting process wouldn't be working because meetingSettingsHelper is null at this time.
             final MeetingSettingsHelper meetingSettingsHelper = ZoomSDK.getInstance().getMeetingSettingsHelper();
             if (meetingSettingsHelper != null) {
               meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
               meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
+              meetingSettingsHelper.disableClearWebKitCache(shouldDisableWebKitCacheClear);
             }
 
             promise.resolve("Already initialize Zoom SDK successfully.");
@@ -848,10 +856,12 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
       initializePromise.resolve("Initialize Zoom SDK successfully.");
       initializePromise = null;
 
+      // This might be the right spot for setMeetingSettings process
       final MeetingSettingsHelper meetingSettingsHelper = ZoomSDK.getInstance().getMeetingSettingsHelper();
       if (meetingSettingsHelper != null) {
         meetingSettingsHelper.disableShowVideoPreviewWhenJoinMeeting(shouldDisablePreview);
         meetingSettingsHelper.setCustomizedMeetingUIEnabled(customizedMeetingUIEnabled);
+        meetingSettingsHelper.disableClearWebKitCache(shouldDisableWebKitCacheClear);
       }
     }
   }

--- a/index.ts
+++ b/index.ts
@@ -1,29 +1,42 @@
-import { NativeModule, Platform } from 'react-native'
-import invariant from 'invariant'
-import { RNZoomUs } from './native'
-import events from './src/events'
+import { NativeModule, Platform } from "react-native";
+import invariant from "invariant";
+import { RNZoomUs } from "./native";
+import events from "./src/events";
 
-const DEFAULT_USER_TYPE = 2
+const DEFAULT_USER_TYPE = 2;
 
-type Language = 'de' | 'ja' | 'en' | 'zh-Hant' | 'es' | 'zh-Hans' | 'it' | 'ko' | 'vi' | 'ru' | 'pt-PT' | 'fr';
+type Language =
+  | "de"
+  | "ja"
+  | "en"
+  | "zh-Hant"
+  | "es"
+  | "zh-Hans"
+  | "it"
+  | "ko"
+  | "vi"
+  | "ru"
+  | "pt-PT"
+  | "fr";
 
 const applyLanguageMapping = (language: Language): string => {
   const androidLanguageMapping = {
-    'zh-Hans': 'zh-CN',
-    'zh-Hant': 'zh-TW',
+    "zh-Hans": "zh-CN",
+    "zh-Hant": "zh-TW",
   };
-  if (Platform.OS === 'android') {
+  if (Platform.OS === "android") {
     return androidLanguageMapping[language] || language;
   }
 
   return language;
-}
+};
 interface RNZoomUsInitializeCommonParams {
   domain?: string;
   iosAppGroupId?: string;
   iosScreenShareExtensionId?: string;
 }
-export interface RNZoomUsInitializeParams extends RNZoomUsInitializeCommonParams {
+export interface RNZoomUsInitializeParams
+  extends RNZoomUsInitializeCommonParams {
   clientKey: string;
   clientSecret: string;
 }
@@ -37,39 +50,50 @@ type InitializeSettings = {
   language?: Language;
   enableCustomizedMeetingUI?: boolean;
   disableShowVideoPreviewWhenJoinMeeting?: boolean;
+  disableMinimizeMeeting?: boolean;
+  disableClearWebKitCache?: boolean;
 };
 
 async function initialize(
   {
-    domain = 'zoom.us',
+    domain = "zoom.us",
     ...params
-  }: RNZoomUsInitializeParams|RNZoomUsSDKInitParams,
+  }: RNZoomUsInitializeParams | RNZoomUsSDKInitParams,
   {
-    language = 'en',
+    language = "en",
     enableCustomizedMeetingUI = false,
 
     // ios only
     // more details inside: https://github.com/mieszko4/react-native-zoom-us/issues/28
-    disableShowVideoPreviewWhenJoinMeeting = true
-  }: InitializeSettings = {},
-): Promise<string> {
-  invariant(typeof params === 'object',
-    'ZoomUs.initialize expects object param. Consider to check migration docs. ' +
-    'Check Link: https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md',
-  )
+    disableShowVideoPreviewWhenJoinMeeting = true,
 
-  if ('jwtToken' in params) {
-    invariant(params.jwtToken, 'ZoomUs.initialize requires jwtToken')
+    // ios only
+    disableMinimizeMeeting = false,
+
+    disableClearWebKitCache = false,
+  }: InitializeSettings = {}
+): Promise<string> {
+  invariant(
+    typeof params === "object",
+    "ZoomUs.initialize expects object param. Consider to check migration docs. " +
+      "Check Link: https://github.com/mieszko4/react-native-zoom-us/blob/master/docs/UPGRADING.md"
+  );
+
+  if ("jwtToken" in params) {
+    invariant(params.jwtToken, "ZoomUs.initialize requires jwtToken");
   } else {
-    invariant(params.clientKey, 'ZoomUs.initialize requires clientKey')
-    invariant(params.clientSecret, 'ZoomUs.initialize requires clientSecret')
+    invariant(params.clientKey, "ZoomUs.initialize requires clientKey");
+    invariant(params.clientSecret, "ZoomUs.initialize requires clientSecret");
   }
 
   const mappedSettings = {
     language: applyLanguageMapping(language),
     enableCustomizedMeetingUI,
 
-    disableShowVideoPreviewWhenJoinMeeting
+    disableShowVideoPreviewWhenJoinMeeting,
+
+    disableMinimizeMeeting,
+    disableClearWebKitCache,
   };
 
   const mappedParams = {
@@ -77,52 +101,58 @@ async function initialize(
     ...params,
   };
 
-  return RNZoomUs.initialize(mappedParams, mappedSettings)
+  return RNZoomUs.initialize(mappedParams, mappedSettings);
 }
 
 function isInitialized(): Promise<boolean> {
-  return RNZoomUs.isInitialized()
+  return RNZoomUs.isInitialized();
 }
 
 export interface RNZoomUsJoinMeetingParams {
-  userName: string
-  meetingNumber: string | number
-  password?: string
-  autoConnectAudio?: boolean
-  noAudio?: boolean
-  noVideo?: boolean
+  userName: string;
+  meetingNumber: string | number;
+  password?: string;
+  autoConnectAudio?: boolean;
+  noAudio?: boolean;
+  noVideo?: boolean;
 
-  noButtonLeave?: boolean
-  noButtonMore?: boolean
-  noButtonParticipants?: boolean
-  noButtonShare?: boolean
-  noTextMeetingId?: boolean
-  noTextPassword?: boolean
-  webinarToken?: string
+  noButtonLeave?: boolean;
+  noButtonMore?: boolean;
+  noButtonParticipants?: boolean;
+  noButtonShare?: boolean;
+  noTextMeetingId?: boolean;
+  noTextPassword?: boolean;
+  webinarToken?: string;
 
   // android only fields:
-  noInvite?: boolean
-  noBottomToolbar?: boolean
-  noPhoneDialIn?: boolean
-  noPhoneDialOut?: boolean
-  noMeetingEndMessage?: boolean
-  noMeetingErrorMessage?: boolean
-  noShare?: boolean
-  noTitlebar?: boolean
-  noDrivingMode?: boolean
-  noDisconnectAudio?: boolean
-  noRecord?: boolean
-  noUnmuteConfirmDialog?: boolean
-  noWebinarRegisterDialog?: boolean
-  noChatMsgToast?: boolean
+  noInvite?: boolean;
+  noBottomToolbar?: boolean;
+  noPhoneDialIn?: boolean;
+  noPhoneDialOut?: boolean;
+  noMeetingEndMessage?: boolean;
+  noMeetingErrorMessage?: boolean;
+  noShare?: boolean;
+  noTitlebar?: boolean;
+  noDrivingMode?: boolean;
+  noDisconnectAudio?: boolean;
+  noRecord?: boolean;
+  noUnmuteConfirmDialog?: boolean;
+  noWebinarRegisterDialog?: boolean;
+  noChatMsgToast?: boolean;
 
   // ios only fields:
-  zoomAccessToken?: string
+  zoomAccessToken?: string;
 }
 async function joinMeeting(params: RNZoomUsJoinMeetingParams) {
-  let { meetingNumber, noAudio = false, noVideo = false, autoConnectAudio = false } = params
-  invariant(meetingNumber, 'ZoomUs.joinMeeting requires meetingNumber')
-  if (typeof meetingNumber !== 'string') meetingNumber = meetingNumber.toString()
+  let {
+    meetingNumber,
+    noAudio = false,
+    noVideo = false,
+    autoConnectAudio = false,
+  } = params;
+  invariant(meetingNumber, "ZoomUs.joinMeeting requires meetingNumber");
+  if (typeof meetingNumber !== "string")
+    meetingNumber = meetingNumber.toString();
 
   // without noAudio, noVideo fields SDK can stack on joining meeting room for release build
   return RNZoomUs.joinMeeting({
@@ -130,118 +160,121 @@ async function joinMeeting(params: RNZoomUsJoinMeetingParams) {
     meetingNumber,
     noAudio: !!noAudio, // required
     noVideo: !!noVideo, // required
-    autoConnectAudio,   // required
-  })
+    autoConnectAudio, // required
+  });
 }
 
 async function joinMeetingWithPassword(
-  userName: RNZoomUsJoinMeetingParams['userName'],
-  meetingNumber: NonNullable<RNZoomUsJoinMeetingParams['meetingNumber']>,
-  password: NonNullable<RNZoomUsJoinMeetingParams['password']>,
+  userName: RNZoomUsJoinMeetingParams["userName"],
+  meetingNumber: NonNullable<RNZoomUsJoinMeetingParams["meetingNumber"]>,
+  password: NonNullable<RNZoomUsJoinMeetingParams["password"]>
 ) {
-  console.warn("ZoomUs.joinMeetingWithPassword is deprecated. Use joinMeeting({ password: 'xxx', ... })")
+  console.warn(
+    "ZoomUs.joinMeetingWithPassword is deprecated. Use joinMeeting({ password: 'xxx', ... })"
+  );
   return joinMeeting({
     userName,
     meetingNumber,
     password,
-  })
+  });
 }
 
 export interface RNZoomUsStartMeetingParams {
-  userName: string
-  meetingNumber: string | number
-  userId: string
-  userType?: number // looks like can be different for IOS and Android
-  zoomAccessToken: string
+  userName: string;
+  meetingNumber: string | number;
+  userId: string;
+  userType?: number; // looks like can be different for IOS and Android
+  zoomAccessToken: string;
 
   // android only fields:
-  noInvite?: boolean
-  noShare?: boolean
-  noMeetingErrorMessage?: boolean
+  noInvite?: boolean;
+  noShare?: boolean;
+  noMeetingErrorMessage?: boolean;
 
-  noButtonLeave?: boolean
-  noButtonMore?: boolean
-  noButtonParticipants?: boolean
-  noButtonShare?: boolean
-  noTextMeetingId?: boolean
-  noTextPassword?: boolean
+  noButtonLeave?: boolean;
+  noButtonMore?: boolean;
+  noButtonParticipants?: boolean;
+  noButtonShare?: boolean;
+  noTextMeetingId?: boolean;
+  noTextPassword?: boolean;
 }
 async function startMeeting(params: RNZoomUsStartMeetingParams) {
-  let { userType = DEFAULT_USER_TYPE, meetingNumber } = params
+  let { userType = DEFAULT_USER_TYPE, meetingNumber } = params;
 
-  invariant(meetingNumber, 'ZoomUs.startMeeting requires meetingNumber')
-  if (typeof meetingNumber !== 'string') meetingNumber = meetingNumber.toString()
+  invariant(meetingNumber, "ZoomUs.startMeeting requires meetingNumber");
+  if (typeof meetingNumber !== "string")
+    meetingNumber = meetingNumber.toString();
 
-  return RNZoomUs.startMeeting({ userType, ...params, meetingNumber })
+  return RNZoomUs.startMeeting({ userType, ...params, meetingNumber });
 }
 
 async function leaveMeeting() {
-  return RNZoomUs.leaveMeeting()
+  return RNZoomUs.leaveMeeting();
 }
 
 async function connectAudio() {
-  return RNZoomUs.connectAudio()
+  return RNZoomUs.connectAudio();
 }
 
 async function isMeetingConnected() {
-  return RNZoomUs.isMeetingConnected()
+  return RNZoomUs.isMeetingConnected();
 }
 
 async function isMeetingHost() {
-  return RNZoomUs.isMeetingHost()
+  return RNZoomUs.isMeetingHost();
 }
 
 async function getInMeetingUserIdList() {
-  return RNZoomUs.getInMeetingUserIdList()
+  return RNZoomUs.getInMeetingUserIdList();
 }
 
 async function rotateMyVideo(rotation: number) {
-  if (Platform.OS === 'android') {
-    return RNZoomUs.rotateMyVideo(rotation)
+  if (Platform.OS === "android") {
+    return RNZoomUs.rotateMyVideo(rotation);
   } else {
-    throw new Error('Only support android')
+    throw new Error("Only support android");
   }
 }
 
 async function muteMyVideo(muted: boolean) {
-  return RNZoomUs.muteMyVideo(muted)
+  return RNZoomUs.muteMyVideo(muted);
 }
 
 async function muteMyAudio(muted: boolean) {
-  return RNZoomUs.muteMyAudio(muted)
+  return RNZoomUs.muteMyAudio(muted);
 }
 
 async function muteAttendee(userId: string, muted: boolean) {
-  return RNZoomUs.muteAttendee(userId, muted)
+  return RNZoomUs.muteAttendee(userId, muted);
 }
 
 async function muteAllAttendee(allowUnmuteSelf: boolean) {
-  return RNZoomUs.muteAllAttendee(allowUnmuteSelf)
+  return RNZoomUs.muteAllAttendee(allowUnmuteSelf);
 }
 
 async function startShareScreen() {
-  return RNZoomUs.startShareScreen()
+  return RNZoomUs.startShareScreen();
 }
 
 async function stopShareScreen() {
-  return RNZoomUs.stopShareScreen()
+  return RNZoomUs.stopShareScreen();
 }
 
 async function switchCamera() {
-  return RNZoomUs.switchCamera()
+  return RNZoomUs.switchCamera();
 }
 
 async function raiseMyHand() {
-  return RNZoomUs.raiseMyHand()
+  return RNZoomUs.raiseMyHand();
 }
 
 async function lowerMyHand() {
-  return RNZoomUs.lowerMyHand()
+  return RNZoomUs.lowerMyHand();
 }
 
-export { default as ZoomUsVideoView } from './video-view'
+export { default as ZoomUsVideoView } from "./video-view";
 
-export * from './src/events'
+export * from "./src/events";
 export default {
   initialize,
   joinMeeting,
@@ -264,4 +297,4 @@ export default {
   raiseMyHand,
   lowerMyHand,
   ...events,
-}
+};

--- a/ios/RNZoomUs.m
+++ b/ios/RNZoomUs.m
@@ -7,9 +7,9 @@
   BOOL shouldAutoConnectAudio;
   BOOL hasObservers;
   BOOL enableCustomMeeting;
-  BOOL showVideoPreviewWhenJoinMeetingDisabled;
-  BOOL minimizeMeetingDisabled;
-  BOOL isDisabledClearWebKitCache;
+  BOOL disableShowVideoPreviewWhenJoinMeeting;
+  BOOL disableMinimizeMeeting;
+  BOOL disableClearWebKitCache;
   RCTPromiseResolveBlock initializePromiseResolve;
   RCTPromiseRejectBlock initializePromiseReject;
   RCTPromiseResolveBlock meetingPromiseResolve;
@@ -26,9 +26,9 @@
     isInitialized = NO;
     shouldAutoConnectAudio = NO;
     enableCustomMeeting = NO;
-    showVideoPreviewWhenJoinMeetingDisabled = NO;
-    minimizeMeetingDisabled = NO;
-    isDisabledClearWebKitCache = NO;
+    disableShowVideoPreviewWhenJoinMeeting = YES;
+    disableMinimizeMeeting = NO;
+    disableClearWebKitCache = NO;
     initializePromiseResolve = nil;
     initializePromiseReject = nil;
     meetingPromiseResolve = nil;
@@ -95,15 +95,15 @@ RCT_EXPORT_METHOD(
     }
     
     if (settings[@"disableShowVideoPreviewWhenJoinMeeting"]) {
-      showVideoPreviewWhenJoinMeetingDisabled = [[settings objectForKey:@"disableShowVideoPreviewWhenJoinMeeting"] boolValue];
+      disableShowVideoPreviewWhenJoinMeeting = [[settings objectForKey:@"disableShowVideoPreviewWhenJoinMeeting"] boolValue];
     }
     
     if (settings[@"disableMinimizeMeeting"]) {
-      minimizeMeetingDisabled = [[settings objectForKey:@"disableMinimizeMeeting"] boolValue];
+      disableMinimizeMeeting = [[settings objectForKey:@"disableMinimizeMeeting"] boolValue];
     }
     
     if (settings[@"disableClearWebKitCache"]) {
-      isDisabledClearWebKitCache = [[settings objectForKey:@"disableClearWebKitCache"] boolValue];
+      disableClearWebKitCache = [[settings objectForKey:@"disableClearWebKitCache"] boolValue];
     }
 
     [[MobileRTC sharedRTC] setLanguage:settings[@"language"]];
@@ -132,9 +132,9 @@ RCT_EXPORT_METHOD(
   MobileRTCMeetingSettings *zoomSettings = [[MobileRTC sharedRTC] getMeetingSettings];
   if (zoomSettings != nil) {
     zoomSettings.enableCustomMeeting = enableCustomMeeting;
-    [zoomSettings disableShowVideoPreviewWhenJoinMeeting:showVideoPreviewWhenJoinMeetingDisabled];
-    [zoomSettings disableMinimizeMeeting:minimizeMeetingDisabled];
-    [zoomSettings disableClearWebKitCache:isDisabledClearWebKitCache];
+    [zoomSettings disableShowVideoPreviewWhenJoinMeeting:disableShowVideoPreviewWhenJoinMeeting];
+    [zoomSettings disableMinimizeMeeting:disableMinimizeMeeting];
+    [zoomSettings disableClearWebKitCache:disableClearWebKitCache];
   }
 }
 
@@ -580,9 +580,6 @@ RCT_EXPORT_METHOD(removeListeners : (NSInteger)count) {
   } else {
     meetingPromiseResolve(@"Connected to zoom meeting");
   }
-
-  // This code is the reason why { autoConnectAudio: true } is not working
-  // shouldAutoConnectAudio = nil;
 
   meetingPromiseResolve = nil;
   meetingPromiseReject = nil;


### PR DESCRIPTION
I added two props into InitializeSettings:

1. disableMinimizeMeeting
- iOS-only property
- From v6.12.0, the minimize meeting button has been changed to a header back button.
- If you set this prop to true, you can disable minimize option and hide back button by this fix.
- Tested in iOS

2. disableClearWebKitCache
- My app is a web app, and since v6.7.0, leaveMeeting of ZoomSDK clear web storage.
- While looking for a solution, I found the disableClearWebKitCache property.
- Web storage is preserved through this fix : Tested in both iOS and Android.
---
- MeetingSettings change is not working in initialize method, so I fixed a spot to change settings.
- I fixed how to retrieve BOOL value from dictionary in iOS.
---
One more extra fix: { autoConnectAudio: true } was not working in iOS
- It will work by this fix : Tested in iOS