### PR TITLE
Android sdk 5.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This is a bridge for ZoomUS SDK.
 
 [![npm](https://img.shields.io/npm/v/react-native-zoom-us)](https://www.npmjs.com/package/react-native-zoom-us)
 
-| Platform      | Version     | SDK Url                                                                      | Changelog                                                            |
-| :-----------: |:------------| :----------------------------------------------------------------------: | :------------------------------------------------------------------: |
-| iOS	        | 5.11.0.3907  | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os    |
-| Android       | 5.11.0.6883 | [jitpack-zoom-us](https://github.com/zoom-us-community/jitpack-zoom-us)  | https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android |
+| Platform | Version     | SDK Url                                                                      |                                          Changelog                                          |
+|:--------:|:------------| :----------------------------------------------------------------------: |:-------------------------------------------------------------------------------------------:|
+|   iOS    | 5.11.3.4099 | [ZoomSDK](https://github.com/zoom-us-community/zoom-sdk-pods)            |  [marketplace.zoom.us](https://marketplace.zoom.us/docs/changelog#labels/client-sdk-i-os)   |
+| Android  | 5.12.2.9109 | [jitpack-zoom-us](https://github.com/zoom-us-community/jitpack-zoom-us)  | [marketplace.zoom.us](https://marketplace.zoom.us/docs/changelog#labels/client-sdk-android) |
 
 Tested on Android and iOS: ([See details](https://github.com/mieszko4/react-native-zoom-us#testing))
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.11.0.6883'
+    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.12.2.9109'
 
     implementation 'com.airbnb.android:lottie:4.0.0'
 
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.window:window-java:1.0.0'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.0'
     implementation 'androidx.core:core-ktx:1.7.0'
-    
+
     // Other Deps (mentioned in docs - not needed)
     /*
     implementation 'androidx.appcompat:appcompat:1.3.1'

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1095,11 +1095,13 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
   @Override
   public void onLocalVideoOrderUpdated(List<Long> localOrderList) {}
   @Override
-  public void onAllHandsLowered() {};
+  public void onAllHandsLowered() {}
   @Override
-  public void onPermissionRequested(String[] permissions) {};
+  public void onPermissionRequested(String[] permissions) {}
   @Override
-  public void onChatMsgDeleteNotification(String msgID, ChatMessageDeleteType deleteBy) {};
+  public void onChatMsgDeleteNotification(String msgID, ChatMessageDeleteType deleteBy) {}
+  @Override
+  public void onShareMeetingChatStatusChanged(boolean start) {}
 
 
   // InMeetingShareListener event listeners


### PR DESCRIPTION
It is update for https://github.com/mieszko4/react-native-zoom-us/pull/219
Note that I selected sub branch for update.

I only added android sdk 5.12.2  and merged master.

Issue with `__emutls_get_address` (https://github.com/mieszko4/react-native-zoom-us/pull/219) is still exists.