### PR TITLE
Fix errors with referencing jitpack version that doesn't exist.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.13.10.12578' // 5.13.10.12577
+    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.13.10.12577' // 5.13.10.12577
 
 
     // Dependencies copied from mobilertc-android-studio/mobilertc/build.gradle


### PR DESCRIPTION
Fixes this issue:

```
FAILURE: Build completed with 2 failures.

1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':app:checkStagingDebugAarMetadata'.
> Could not resolve all files for configuration ':app:StagingDebugRuntimeClasspath'.
   > Failed to transform mobilertc-5.13.10.12578.aar (com.github.zoom-us-community.jitpack-zoom-us:mobilertc:5.13.10.12578) to match attributes {artifactType=a
ndroid-aar-metadata, org.gradle.status=release}.
      > Could not find mobilertc-5.13.10.12578.aar (com.github.zoom-us-community.jitpack-zoom-us:mobilertc:5.13.10.12578).
        Searched in the following locations:
            https://www.jitpack.io/com/github/zoom-us-community/jitpack-zoom-us/mobilertc/5.13.10.12578/mobilertc-5.13.10.12578.aar
```