### PR TITLE
fix: update android dependencies from 5.16.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,9 +53,10 @@ dependencies {
     implementation 'com.google.android.flexbox:flexbox:3.0.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.code.gson:gson:2.8.1'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.github.bumptech.glide:annotations:4.11.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'org.greenrobot:eventbus:3.1.1'
 
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'com.airbnb.android:lottie:4.0.0'
@@ -64,12 +65,17 @@ dependencies {
 
     implementation 'androidx.window:window-java:1.0.0'
 
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.8.20'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.20'
+
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.2'
     implementation 'androidx.core:core-ktx:1.8.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata:2.4.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
 
     implementation 'androidx.fragment:fragment-ktx:1.4.1'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'org.greenrobot:eventbus:3.1.1'
+    implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
 }


### PR DESCRIPTION
Fix after releasing https://github.com/mieszko4/react-native-zoom-us/pull/314

Closes https://github.com/mieszko4/react-native-zoom-us/issues/327

### Test plan
- [x] Join meeting on Android
- [x] Press on chat button and send a msg