### PR TITLE
Update Zoom SDK version to resolve app crashing on Android 14

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,8 @@ android {
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
 
-    implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.16.2.16555'
+    // implementation 'com.github.zoom-us-community:jitpack-zoom-us:5.16.2.16555'
+    implementation 'com.github.chirag-codealchemy:zoom:5.17.1.18530'
 
     // Dependencies copied from mobilertc-android-studio/mobilertc/build.gradle
     // NB: We use com.google.android.flexbox:flexbox:3.0.0 because of "Could not find com.google.android:flexbox:2.0.1"
@@ -78,4 +79,9 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'org.greenrobot:eventbus:3.1.1'
     implementation 'com.davemorrissey.labs:subsampling-scale-image-view:3.10.0'
+
+    // newly added deps(refer zoom SDK doc) 
+    implementation 'androidx.core:core-splashscreen:1.0.1'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.6.1'
+    implementation 'androidx.databinding:viewbinding:7.1.2'
 }

--- a/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
+++ b/android/src/main/java/ch/milosz/reactnative/RNZoomUsModule.java
@@ -1026,6 +1026,15 @@ public class RNZoomUsModule extends ReactContextBaseJavaModule implements ZoomSD
     }
   }
 
+
+  // refer zoom SDK doc 
+  @Override
+  public void onAICompanionActiveChangeNotice(boolean b) {}
+  @Override
+  public void onParticipantProfilePictureStatusChange(boolean b) {}
+  @Override
+  public void onCloudRecordingStorageFull(long l) {}
+  
   @Override
   public void onInMeetingUserAvatarPathUpdated(long userId) {}
   @Override


### PR DESCRIPTION

Problem:
The app was experiencing crashes on devices running Android 14 due to compatibility issues with Zoom SDK version 5.16.2.16555. This was causing inconvenience to users and impacting the app's performance.

Solution:
To address this issue, I have updated the Zoom SDK version from 5.16.2.16555 to 5.17.1.18530. This change has resolved the crashes on Android 14 devices, ensuring a smoother user experience.

Rationale:
Although the latest version of the Zoom SDK is available, it was causing crashes when users attempted to join meetings. The error message indicated that the SDK targeting U+ (version 34 and above) disallows certain flags for security reasons. To avoid these crashes, I opted for version 5.17.1.18530, which provides stability without encountering the aforementioned error.

Changes Made:
Updated Zoom SDK version from 5.16.2.16555 to 5.17.1.18530 in the project dependencies.
Testing:
I have thoroughly tested the app on devices running Android 14 to ensure that the crashes no longer occur. Additionally, I have verified that the app functions as expected, including joining meetings without encountering the error mentioned above.

Impact:
This change resolves the crashing issue on Android 14 devices, improving the overall reliability and usability of the app for affected users.

Useful Links:
[Zoom Developer Forum - Android 14 Crash Issue](https://devforum.zoom.us/t/zoom-meeting-sdk-v5-16-5-17050-crashing-in-android-version-14-devices/98461)
[Zoom Developer Forum - Latest Version Crash Issue](https://devforum.zoom.us/t/getting-error-when-join-meeting-in-android-sdk/103290)
[Zoom SDK Change Log - Version 5.17.0](https://developers.zoom.us/changelog/meeting-sdk/android/5.17.0)